### PR TITLE
遠征条件確認の改善

### DIFF
--- a/src/main/java/logbook/bean/TestAllPredicate.java
+++ b/src/main/java/logbook/bean/TestAllPredicate.java
@@ -1,5 +1,6 @@
 package logbook.bean;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 
@@ -22,5 +23,50 @@ public interface TestAllPredicate<T> extends Predicate<T> {
             boolean result2 = other.test(t);
             return result1 || result2;
         };
+    }
+
+    /**
+     * 条件(論理演算)
+     * @return 論理演算を行う Predicate
+     */
+    default Predicate<T> processOperator(String operator, List<? extends TestAllPredicate<T>> conditions) {
+        Predicate<T> predicate = null;
+        for (TestAllPredicate<T> condition : conditions) {
+            if (predicate == null) {
+                predicate = condition;
+            } else {
+                predicate = operator.endsWith("AND")
+                        ? predicate.and(condition)
+                        : predicate.or(condition);
+            }
+        }
+        if ("NAND".equals(operator) || "NOR".equals(operator)) {
+            predicate = predicate.negate();
+        }
+        return predicate;
+    }
+
+    default String toStringOperator(String operator, String description) {
+        StringBuilder sb = new StringBuilder(64);
+        switch (operator) {
+        case "AND":
+            sb.append("次の条件を全て満たす");
+            break;
+        case "OR":
+            sb.append("次の条件のいずれか少なくとも1つを満たす");
+            break;
+        case "NAND":
+            sb.append("次の条件のいずれか少なくとも1つを満たさない");
+            break;
+        case "NOR":
+            sb.append("次の条件を全て満たさない");
+            break;
+        default:
+            break;
+        }
+        if (description != null) {
+            sb.append("(").append(description).append(")");
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/logbook/internal/ImageListener.java
+++ b/src/main/java/logbook/internal/ImageListener.java
@@ -64,6 +64,9 @@ public class ImageListener implements ContentListenerSpi {
             if (uri.startsWith("/kcs2/img/duty/")) {
                 this.images(request, response, "duty");
             }
+            if (uri.startsWith("/kcs2/img/sally/")) {
+                this.images(request, response, "sally");
+            }
         } catch (Exception e) {
             LoggerHolder.get().warn("画像ファイル処理中に例外が発生しました", e);
         }

--- a/src/main/java/logbook/internal/Missions.java
+++ b/src/main/java/logbook/internal/Missions.java
@@ -2,11 +2,19 @@ package logbook.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import javafx.scene.SnapshotParameters;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.image.Image;
+import javafx.scene.paint.Color;
+import logbook.bean.AppConfig;
 import logbook.bean.Mission;
 import logbook.bean.MissionCollection;
 import logbook.bean.MissionCondition;
@@ -17,6 +25,9 @@ import logbook.plugin.PluginServices;
  *
  */
 public class Missions {
+
+    /** 画像キャッシュ */
+    private static final ReferenceCache<String, Image> CACHE = new ReferenceCache<>(50);
 
     /**
      * 遠征IDから{@link Mission}を返します。
@@ -65,5 +76,77 @@ public class Missions {
         }
 
         return Optional.ofNullable(condition);
+    }
+
+    /**
+     * 遠征の定義から時間を表すテキストを返します。
+     * @param mission 遠征定義
+     * @return テキスト - 30分、3時間15分、1日など
+     */
+    public static String getDurationText(Mission mission) {
+        if (mission.getTime() != null) {
+            int minutes = mission.getTime();
+            final int DAY_IN_MINUTE = 60*24;
+            StringBuilder sb = new StringBuilder(16);
+            if (minutes >= DAY_IN_MINUTE) {
+                int days = minutes/DAY_IN_MINUTE;
+                minutes -= days*DAY_IN_MINUTE;
+                sb.append(days).append("日");
+            }
+            if (minutes >= 60) {
+                int hours = minutes/60;
+                minutes -= hours*60;
+                sb.append(hours).append("時間");
+            }
+            if (minutes > 0) {
+                sb.append(minutes).append("分");
+            }
+            return sb.toString();
+        }
+        return "(不明)";
+    }
+
+    public static Image damageTypeIcon(int damageType) {
+        if (damageType == 1) {
+            return expeditionIcon(68, 24, 18);
+        } else if (damageType == 2) {
+            return expeditionIcon(69, 24, 18);
+        }
+        return null;
+    }
+
+    /**
+     * 遠征画像をロードします。
+     *
+     * @param id 画像ID
+     * @param prefWidth 幅
+     * @param prefHeight 高さ
+     * @return 画像
+     */
+    private static Image expeditionIcon(int id, int prefWidth, int prefHeight) {
+        Path dir = Paths.get(AppConfig.get().getResourcesDir());
+        Path p = dir.resolve(Paths.get("sally", "sally_expedition/sally_expedition_" + id + ".png"));
+
+        return CACHE.get(p.toUri().toString()+"@"+prefWidth+"x"+prefHeight, (url, status) -> {
+            Image image = new Image(url.substring(0, url.lastIndexOf("@")));
+            if (image.isError()) {
+                status.setDoCache(false);
+                return null;
+            }
+            double width = image.getWidth();
+            double height = image.getHeight();
+
+            if (width != prefWidth || height != prefHeight) {
+                Canvas canvas = new Canvas(prefWidth, prefHeight);
+                GraphicsContext gc = canvas.getGraphicsContext2D();
+
+                gc.drawImage(image, 0, 0, prefWidth, prefHeight);
+                SnapshotParameters sp = new SnapshotParameters();
+                sp.setFill(Color.TRANSPARENT);
+
+                return canvas.snapshot(sp, null);
+            }
+            return image;
+        });
     }
 }

--- a/src/main/resources/logbook/mission/1/A2.json
+++ b/src/main/resources/logbook/mission/1/A2.json
@@ -1,6 +1,9 @@
 /*海峡警備行動*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "対潜", "value": 180},
         {

--- a/src/main/resources/logbook/mission/1/A3.json
+++ b/src/main/resources/logbook/mission/1/A3.json
@@ -1,6 +1,9 @@
 /*長時間対潜警戒*/
 {
     "operator": "AND",
+        "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "レベル", "value": 185},
         {"type": "艦隊", "count_type": "対潜", "value": 280},

--- a/src/main/resources/logbook/mission/1/A4.json
+++ b/src/main/resources/logbook/mission/1/A4.json
@@ -1,6 +1,9 @@
 /*南西方面連絡線哨戒*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 300},
         {"type": "艦隊", "count_type": "対潜", "value": 200},

--- a/src/main/resources/logbook/mission/1/A5.json
+++ b/src/main/resources/logbook/mission/1/A5.json
@@ -1,6 +1,9 @@
 /*小笠原沖哨戒線*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 280},
         {"type": "艦隊", "count_type": "対空", "value": 220},

--- a/src/main/resources/logbook/mission/1/A6.json
+++ b/src/main/resources/logbook/mission/1/A6.json
@@ -1,6 +1,9 @@
 /*小笠原沖戦闘哨戒*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 330},
         {"type": "艦隊", "count_type": "対空", "value": 300},

--- a/src/main/resources/logbook/mission/2/B3.json
+++ b/src/main/resources/logbook/mission/2/B3.json
@@ -1,6 +1,9 @@
 /*南西諸島離島哨戒作戦*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 400},
         {

--- a/src/main/resources/logbook/mission/2/B4.json
+++ b/src/main/resources/logbook/mission/2/B4.json
@@ -1,6 +1,9 @@
 /*南西諸島離島防衛作戦*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 500},
         {"type": "艦隊", "count_type": "対潜", "value": 280},

--- a/src/main/resources/logbook/mission/2/B5.json
+++ b/src/main/resources/logbook/mission/2/B5.json
@@ -1,6 +1,9 @@
 /*南西諸島捜索撃滅戦*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 510},
         {"type": "艦隊", "count_type": "対空", "value": 400},

--- a/src/main/resources/logbook/mission/3/21.json
+++ b/src/main/resources/logbook/mission/3/21.json
@@ -1,6 +1,13 @@
 /*北方鼠輸送作戦*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+        "operator": "AND",
+        "conditions": [
+            {"type": "艦隊", "count_type": "キラキラ",  "value": 4},
+            {"type": "艦隊", "count_type": "装備", "item": "ドラム缶(輸送用)", "value": 4}
+        ]
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "レベル", "value": 30},
         {

--- a/src/main/resources/logbook/mission/3/24.json
+++ b/src/main/resources/logbook/mission/3/24.json
@@ -1,6 +1,13 @@
 /*北方航路海上護衛*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+        "operator": "AND",
+        "conditions": [
+            {"type": "艦隊", "count_type": "キラキラ",  "value": 4},
+            {"type": "艦隊", "count_type": "装備", "item": "ドラム缶(輸送用)", "value": 4}
+        ]
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "レベル", "value": 200},
         {

--- a/src/main/resources/logbook/mission/4/32.json
+++ b/src/main/resources/logbook/mission/4/32.json
@@ -1,6 +1,9 @@
 /*遠洋練習航海*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦娘", "ship_type" :["練習巡洋艦"], "level": 5, "order": 1},
         {"type": "艦娘", "ship_type" :["駆逐艦"]},

--- a/src/main/resources/logbook/mission/4/D1.json
+++ b/src/main/resources/logbook/mission/4/D1.json
@@ -1,6 +1,9 @@
 /*西方海域偵察作戦*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "対空", "value": 240},
         {"type": "艦隊", "count_type": "対潜", "value": 240},

--- a/src/main/resources/logbook/mission/4/D2.json
+++ b/src/main/resources/logbook/mission/4/D2.json
@@ -1,6 +1,9 @@
 /*西方潜水艦作戦*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 60},
         {"type": "艦隊", "count_type": "対空", "value": 80},

--- a/src/main/resources/logbook/mission/5/37.json
+++ b/src/main/resources/logbook/mission/5/37.json
@@ -1,6 +1,13 @@
 /*東京急行*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+        "operator": "AND",
+        "conditions": [
+            {"type": "艦隊", "count_type": "キラキラ",  "value": 4},
+            {"type": "艦隊", "count_type": "装備", "item": "ドラム缶(輸送用)", "value": 5}
+        ]
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "レベル", "value": 200},
         {

--- a/src/main/resources/logbook/mission/5/38.json
+++ b/src/main/resources/logbook/mission/5/38.json
@@ -1,6 +1,13 @@
 /*東京急行(弐)*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+        "operator": "AND",
+        "conditions": [
+            {"type": "艦隊", "count_type": "キラキラ",  "value": 4},
+            {"type": "艦隊", "count_type": "装備", "item": "ドラム缶(輸送用)", "value": 10}
+        ]
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "レベル", "value": 240},
         {

--- a/src/main/resources/logbook/mission/5/40.json
+++ b/src/main/resources/logbook/mission/5/40.json
@@ -1,6 +1,13 @@
 /*水上機前線輸送*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+        "operator": "AND",
+        "conditions": [
+            {"type": "艦隊", "count_type": "キラキラ",  "value": 4},
+            {"type": "艦隊", "count_type": "装備", "item": "ドラム缶(輸送用)", "value": 4}
+        ]
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "レベル", "value": 150},
         {

--- a/src/main/resources/logbook/mission/5/E1.json
+++ b/src/main/resources/logbook/mission/5/E1.json
@@ -1,6 +1,9 @@
 /*ラバウル方面艦隊進出*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 450},
         {"type": "艦隊", "count_type": "対空", "value": 350},

--- a/src/main/resources/logbook/mission/7/41.json
+++ b/src/main/resources/logbook/mission/7/41.json
@@ -1,6 +1,9 @@
 /*ブルネイ泊地沖哨戒*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "レベル", "value": 100},
         {"type": "艦隊", "count_type": "対潜", "value": 210},

--- a/src/main/resources/logbook/mission/7/43.json
+++ b/src/main/resources/logbook/mission/7/43.json
@@ -1,6 +1,9 @@
 /*ミ船団護衛(二号船団)*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "火力", "value": 500},
         {"type": "艦隊", "count_type": "対潜", "value": 280},

--- a/src/main/resources/logbook/mission/7/44.json
+++ b/src/main/resources/logbook/mission/7/44.json
@@ -1,6 +1,13 @@
 /*航空装備輸送任務*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+        "operator": "AND",
+        "conditions": [
+            {"type": "艦隊", "count_type": "キラキラ",  "value": 4},
+            {"type": "艦隊", "count_type": "装備", "item": "ドラム缶(輸送用)", "value": 8}
+        ]
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "対潜", "value": 200},
         {

--- a/src/main/resources/logbook/mission/7/45.json
+++ b/src/main/resources/logbook/mission/7/45.json
@@ -1,6 +1,9 @@
 /*ボーキサイト船団護衛*/
 {
     "operator": "AND",
+    "greatSuccessCondition": {
+         "type": "艦隊", "count_type": "旗艦レベル＋キラキラ"
+    },
     "conditions": [
         {"type": "艦隊", "count_type": "対空", "value": 240},
         {"type": "艦隊", "count_type": "対潜", "value": 300},


### PR DESCRIPTION
#### 変更内容
遠征条件確認に改善を加える。
- 大成功条件の表示とともに成功予想時のチェックマークをオレンジに
- 遠征時間の表示
- 交戦型、交戦型II の表示
![image](https://user-images.githubusercontent.com/3181895/93664889-237e7e00-faad-11ea-953a-c93173782d40.png)

#### 関連するIssue
N/A
