### PR TITLE
種々の統計ビューの改善

### DIFF
--- a/src/main/java/logbook/api/ApiPortPort.java
+++ b/src/main/java/logbook/api/ApiPortPort.java
@@ -239,7 +239,7 @@ public class ApiPortPort implements APIListenerSpi {
             if (eventObject.containsKey("api_m_flag2")) {
                 if (JsonHelper.toInteger(eventObject.get("api_m_flag2")) > 0) {
                     Platform.runLater(
-                            () -> Tools.Conrtols.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。",
+                            () -> Tools.Controls.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。",
                                     javafx.util.Duration.seconds(15)));
                     // 通知音再生
                     if (AppConfig.get().isUseSound()) {

--- a/src/main/java/logbook/api/ApiReqCombinedBattleBattleresult.java
+++ b/src/main/java/logbook/api/ApiReqCombinedBattleBattleresult.java
@@ -80,7 +80,7 @@ public class ApiReqCombinedBattleBattleresult implements APIListenerSpi {
             }
             if (result.achievementGimmick1()) {
                 Platform.runLater(
-                        () -> Tools.Conrtols.showNotify(null, "ギミック解除", "海域に変化が確認されました。", Duration.seconds(15)));
+                        () -> Tools.Controls.showNotify(null, "ギミック解除", "海域に変化が確認されました。", Duration.seconds(15)));
                 // 通知音再生
                 if (AppConfig.get().isUseSound()) {
                     Platform.runLater(Audios.playDefaultNotifySound());
@@ -92,7 +92,7 @@ public class ApiReqCombinedBattleBattleresult implements APIListenerSpi {
             }
             if (result.achievementGimmick2()) {
                 Platform.runLater(
-                        () -> Tools.Conrtols.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。", Duration.seconds(15)));
+                        () -> Tools.Controls.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。", Duration.seconds(15)));
                 // 通知音再生
                 if (AppConfig.get().isUseSound()) {
                     Platform.runLater(Audios.playDefaultNotifySound());

--- a/src/main/java/logbook/api/ApiReqMapNext.java
+++ b/src/main/java/logbook/api/ApiReqMapNext.java
@@ -84,7 +84,7 @@ public class ApiReqMapNext implements APIListenerSpi {
             }
             if (next.achievementGimmick1()) {
                 Platform.runLater(
-                        () -> Tools.Conrtols.showNotify(null, "ギミック解除", "海域に変化が確認されました。", Duration.seconds(15)));
+                        () -> Tools.Controls.showNotify(null, "ギミック解除", "海域に変化が確認されました。", Duration.seconds(15)));
                 // 通知音再生
                 if (AppConfig.get().isUseSound()) {
                     Platform.runLater(Audios.playDefaultNotifySound());
@@ -96,7 +96,7 @@ public class ApiReqMapNext implements APIListenerSpi {
             }
             if (next.achievementGimmick2()) {
                 Platform.runLater(
-                        () -> Tools.Conrtols.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。", Duration.seconds(15)));
+                        () -> Tools.Controls.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。", Duration.seconds(15)));
                 // 通知音再生
                 if (AppConfig.get().isUseSound()) {
                     Platform.runLater(Audios.playDefaultNotifySound());
@@ -133,7 +133,7 @@ public class ApiReqMapNext implements APIListenerSpi {
                     .map(ShipMst::getName)
                     .orElse(""), ship.getLv());
 
-            Tools.Conrtols.showNotify(node, "大破警告", message, Duration.seconds(30));
+            Tools.Controls.showNotify(node, "大破警告", message, Duration.seconds(30));
         }
     }
 

--- a/src/main/java/logbook/api/ApiReqMapStart.java
+++ b/src/main/java/logbook/api/ApiReqMapStart.java
@@ -107,7 +107,7 @@ public class ApiReqMapStart implements APIListenerSpi {
                     .map(ShipMst::getName)
                     .orElse(""), ship.getLv());
 
-            Tools.Conrtols.showNotify(node, "大破警告", message, Duration.seconds(30));
+            Tools.Controls.showNotify(node, "大破警告", message, Duration.seconds(30));
         }
     }
 

--- a/src/main/java/logbook/api/ApiReqMissionStart.java
+++ b/src/main/java/logbook/api/ApiReqMissionStart.java
@@ -87,7 +87,7 @@ public class ApiReqMissionStart implements APIListenerSpi {
                 .append("」")
                 .append("の条件を満たしていません");
 
-        Tools.Conrtols.showNotify(null, "遠征警告", sb.toString(), Duration.seconds(10));
+        Tools.Controls.showNotify(null, "遠征警告", sb.toString(), Duration.seconds(10));
     }
 
     /**

--- a/src/main/java/logbook/api/ApiReqSortieBattleresult.java
+++ b/src/main/java/logbook/api/ApiReqSortieBattleresult.java
@@ -78,7 +78,7 @@ public class ApiReqSortieBattleresult implements APIListenerSpi {
             }
             if (result.achievementGimmick1()) {
                 Platform.runLater(
-                        () -> Tools.Conrtols.showNotify(null, "ギミック解除", "海域に変化が確認されました。", Duration.seconds(15)));
+                        () -> Tools.Controls.showNotify(null, "ギミック解除", "海域に変化が確認されました。", Duration.seconds(15)));
                 // 通知音再生
                 if (AppConfig.get().isUseSound()) {
                     Platform.runLater(Audios.playDefaultNotifySound());
@@ -90,7 +90,7 @@ public class ApiReqSortieBattleresult implements APIListenerSpi {
             }
             if (result.achievementGimmick2()) {
                 Platform.runLater(
-                        () -> Tools.Conrtols.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。", Duration.seconds(15)));
+                        () -> Tools.Controls.showNotify(null, "ギミック解除", "ギミックの達成を確認しました。", Duration.seconds(15)));
                 // 通知音再生
                 if (AppConfig.get().isUseSound()) {
                     Platform.runLater(Audios.playDefaultNotifySound());

--- a/src/main/java/logbook/bean/AppViewConfig.java
+++ b/src/main/java/logbook/bean/AppViewConfig.java
@@ -18,6 +18,8 @@ public class AppViewConfig {
 
     private BattleLogConfig battleLogConfig;
 
+    private CreateItemLogConfig createItemLogConfig;
+
     @Data
     public static class BattleLogConfig {
         private List<CustomUnit> customUnits;
@@ -29,6 +31,11 @@ public class AppViewConfig {
             private long from;
             private long to;
         }
+    }
+
+    @Data
+    public static class CreateItemLogConfig {
+        private int index;
     }
 
     /**

--- a/src/main/java/logbook/bean/AppViewConfig.java
+++ b/src/main/java/logbook/bean/AppViewConfig.java
@@ -2,6 +2,9 @@ package logbook.bean;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 import logbook.internal.Config;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -20,6 +23,8 @@ public class AppViewConfig {
 
     private CreateItemLogConfig createItemLogConfig;
 
+    private ResourceChartConfig resourceChartConfig;
+
     @Data
     public static class BattleLogConfig {
         private List<CustomUnit> customUnits;
@@ -36,6 +41,23 @@ public class AppViewConfig {
     @Data
     public static class CreateItemLogConfig {
         private int index;
+    }
+
+    @Data
+    @JsonInclude(Include.NON_DEFAULT)
+    public static class ResourceChartConfig {
+        private int termIndex = 2;
+        private Long from;
+        private Long to;
+        private boolean fuel = true;
+        private boolean ammo = true;
+        private boolean metal = true;
+        private boolean bauxite = true;
+        private boolean bucket;
+        private boolean burner;
+        private boolean research;
+        private boolean improve;
+        private boolean forceZero;
     }
 
     /**

--- a/src/main/java/logbook/bean/AppViewConfig.java
+++ b/src/main/java/logbook/bean/AppViewConfig.java
@@ -1,0 +1,46 @@
+package logbook.bean;
+
+import java.util.List;
+
+import logbook.internal.Config;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * ビュー回りの状態
+ * 
+ * アプリケーションの設定と異なり、マシンを変更した時など引き継がなくてもいい情報はこちらに保存する。
+ * 今 AppConfig にあるテーブルのカラム幅の情報等もそのうちこちらにまとめる予定。
+ */
+@Data
+public class AppViewConfig {
+
+    private BattleLogConfig battleLogConfig;
+
+    @Data
+    public static class BattleLogConfig {
+        private List<CustomUnit> customUnits;
+
+        @Data
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class CustomUnit {
+            private long from;
+            private long to;
+        }
+    }
+
+    /**
+     * アプリケーションのデフォルト設定ディレクトリから<code>AppViewConfig</code>を取得します、
+     * これは次の記述と同等です
+     * <blockquote>
+     *     <code>Config.getDefault().get(AppViewConfig.class, AppViewConfig::new)</code>
+     * </blockquote>
+     *
+     * @return <code>AppViewConfig</code>
+     */
+    public static AppViewConfig get() {
+        return Config.getDefault().get(AppViewConfig.class, AppViewConfig::new);
+    }
+}

--- a/src/main/java/logbook/internal/CheckUpdate.java
+++ b/src/main/java/logbook/internal/CheckUpdate.java
@@ -70,7 +70,7 @@ public class CheckUpdate {
         if (!Version.UNKNOWN.equals(remoteVersion) && Version.getCurrent().compareTo(remoteVersion) < 0) {
             Platform.runLater(() -> CheckUpdate.openInfo(Version.getCurrent(), remoteVersion, isStartUp, stage));
         } else if (!isStartUp) {
-            Tools.Conrtols.alert(AlertType.INFORMATION, "更新の確認", "最新のバージョンです。", stage);
+            Tools.Controls.alert(AlertType.INFORMATION, "更新の確認", "最新のバージョンです。", stage);
         }
     }
 

--- a/src/main/java/logbook/internal/ToStringConverter.java
+++ b/src/main/java/logbook/internal/ToStringConverter.java
@@ -20,7 +20,7 @@ public class ToStringConverter<T> extends StringConverter<T> {
     @Override
     public String toString(T object) {
         if (object != null) {
-            return converter.apply(object);
+            return this.converter.apply(object);
         } else {
             return "";
         }

--- a/src/main/java/logbook/internal/gui/AirBaseController.java
+++ b/src/main/java/logbook/internal/gui/AirBaseController.java
@@ -142,7 +142,7 @@ public class AirBaseController extends WindowController {
             // SplitPaneの分割サイズ
             Timeline x = new Timeline();
             x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-                Tools.Conrtols.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
+                Tools.Controls.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
             }));
             x.play();
             this.areaTable.setShowRoot(false);

--- a/src/main/java/logbook/internal/gui/BattleDetail.java
+++ b/src/main/java/logbook/internal/gui/BattleDetail.java
@@ -264,7 +264,7 @@ public class BattleDetail extends WindowController {
         if (source != null) {
             source.setVisible(false);
         }
-        Tools.Conrtols.storeSnapshot(this.detail, "戦闘ログのスナップショット", this.getWindow());
+        Tools.Controls.storeSnapshot(this.detail, "戦闘ログのスナップショット", this.getWindow());
         if (source != null) {
             source.setVisible(true);
         }

--- a/src/main/java/logbook/internal/gui/BattleLogController.java
+++ b/src/main/java/logbook/internal/gui/BattleLogController.java
@@ -118,6 +118,10 @@ public class BattleLogController extends WindowController {
     @FXML
     private TableView<BattleLogDetail> detail;
 
+    /** 行番号 */
+    @FXML
+    private TableColumn<BattleLogDetail, Integer> row;
+
     /** 日付 */
     @FXML
     private TableColumn<BattleLogDetail, String> date;
@@ -285,6 +289,7 @@ public class BattleLogController extends WindowController {
             this.detail.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
             this.detail.setOnKeyPressed(TableTool::defaultOnKeyPressedHandler);
 
+            this.row.setCellFactory(TableTool.getRowCountCellFactory());
             this.date.setCellValueFactory(new PropertyValueFactory<>("date"));
             this.area.setCellValueFactory(new PropertyValueFactory<>("area"));
             this.cell.setCellValueFactory(new PropertyValueFactory<>("cell"));

--- a/src/main/java/logbook/internal/gui/BattleLogController.java
+++ b/src/main/java/logbook/internal/gui/BattleLogController.java
@@ -236,8 +236,8 @@ public class BattleLogController extends WindowController {
             // SplitPaneの分割サイズ
             Timeline x = new Timeline();
             x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-                Tools.Conrtols.setSplitWidth(this.splitPane1, this.getClass() + "#" + "splitPane1");
-                Tools.Conrtols.setSplitWidth(this.splitPane2, this.getClass() + "#" + "splitPane2");
+                Tools.Controls.setSplitWidth(this.splitPane1, this.getClass() + "#" + "splitPane1");
+                Tools.Controls.setSplitWidth(this.splitPane2, this.getClass() + "#" + "splitPane2");
             }));
             x.play();
             // 統計

--- a/src/main/java/logbook/internal/gui/BattleLogScriptController.java
+++ b/src/main/java/logbook/internal/gui/BattleLogScriptController.java
@@ -102,7 +102,7 @@ public class BattleLogScriptController extends WindowController {
 
     @FXML
     void remove() {
-        ButtonType result = Tools.Conrtols.alert(AlertType.CONFIRMATION,
+        ButtonType result = Tools.Controls.alert(AlertType.CONFIRMATION,
                 "スクリプトの削除", "このスクリプトを削除しますか？", this.getWindow())
                 .orElse(null);
         if (!ButtonType.OK.equals(result)) {
@@ -134,7 +134,7 @@ public class BattleLogScriptController extends WindowController {
             return;
         }
         if (!this.current.getScript().equals(this.editor.get())) {
-            ButtonType result = Tools.Conrtols.alert(AlertType.CONFIRMATION,
+            ButtonType result = Tools.Controls.alert(AlertType.CONFIRMATION,
                     "スクリプトの保存", "スクリプトは保存されていません。\n保存せず実行しますか？", this.getWindow())
                     .orElse(null);
             if (!ButtonType.OK.equals(result)) {

--- a/src/main/java/logbook/internal/gui/CalcExpController.java
+++ b/src/main/java/logbook/internal/gui/CalcExpController.java
@@ -133,7 +133,7 @@ public class CalcExpController extends WindowController {
         // SplitPaneの分割サイズ
         Timeline x = new Timeline();
         x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-            Tools.Conrtols.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
+            Tools.Controls.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
         }));
         x.play();
         // Spinnerに最小値最大値現在値を設定
@@ -506,7 +506,7 @@ public class CalcExpController extends WindowController {
             super.updateItem(ship, empty);
 
             if (!empty) {
-                this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
+                this.setGraphic(Tools.Controls.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
                 this.setText(Ships.shipMst(ship)
                         .map(ShipMst::getName)
                         .orElse(""));

--- a/src/main/java/logbook/internal/gui/CaptureController.java
+++ b/src/main/java/logbook/internal/gui/CaptureController.java
@@ -218,7 +218,7 @@ public class CaptureController extends WindowController {
             rectangle.height = bean.getHeight();
             this.setBounds(this.sc.getRobot(), rectangle);
         } else {
-            Tools.Conrtols.alert(AlertType.INFORMATION, "範囲を編集", "範囲を編集するには自動または手動で範囲を設定してください", this.getWindow());
+            Tools.Controls.alert(AlertType.INFORMATION, "範囲を編集", "範囲を編集するには自動または手動で範囲を設定してください", this.getWindow());
         }
     }
 
@@ -248,7 +248,7 @@ public class CaptureController extends WindowController {
         if ((AppConfig.get().getFfmpegPath() == null || AppConfig.get().getFfmpegPath().isEmpty())
                 || (AppConfig.get().getFfmpegArgs() == null || AppConfig.get().getFfmpegArgs().isEmpty())
                 || (AppConfig.get().getFfmpegExt() == null || AppConfig.get().getFfmpegExt().isEmpty())) {
-            Tools.Conrtols.alert(AlertType.INFORMATION, "設定が必要です", "[設定]メニューの[キャプチャ]タブから"
+            Tools.Controls.alert(AlertType.INFORMATION, "設定が必要です", "[設定]メニューの[キャプチャ]タブから"
                     + "FFmpegパスおよび引数を設定してください。", this.getWindow());
             this.movie.setSelected(false);
         }
@@ -406,7 +406,7 @@ public class CaptureController extends WindowController {
                 this.end = new Point2D(e.getX(), e.getY());
                 if (!this.start.equals(this.end)) {
 
-                    Optional<ButtonType> buttonType = Tools.Conrtols.alert(Alert.AlertType.CONFIRMATION,
+                    Optional<ButtonType> buttonType = Tools.Controls.alert(Alert.AlertType.CONFIRMATION,
                             "矩形選択",
                             "この範囲でよろしいですか？",
                             stage);
@@ -542,7 +542,7 @@ public class CaptureController extends WindowController {
             this.process = pb.start();
         } catch (Exception e) {
             this.stopProcess();
-            Tools.Conrtols.alert(AlertType.ERROR, "動画撮影に失敗しました", "設定が誤っている可能性があります。\n引数:" + args.toString(), e,
+            Tools.Controls.alert(AlertType.ERROR, "動画撮影に失敗しました", "設定が誤っている可能性があります。\n引数:" + args.toString(), e,
                     this.getWindow());
         }
     }

--- a/src/main/java/logbook/internal/gui/CaptureSaveController.java
+++ b/src/main/java/logbook/internal/gui/CaptureSaveController.java
@@ -71,7 +71,7 @@ public class CaptureSaveController extends WindowController {
         // SplitPaneの分割サイズ
         Timeline x = new Timeline();
         x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-            Tools.Conrtols.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
+            Tools.Controls.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
         }));
         x.play();
         this.image.fitWidthProperty().bind(this.imageParent.widthProperty());
@@ -120,7 +120,7 @@ public class CaptureSaveController extends WindowController {
                     protected void succeeded() {
                         super.succeeded();
 
-                        Tools.Conrtols.alert(AlertType.INFORMATION,
+                        Tools.Controls.alert(AlertType.INFORMATION,
                                 "キャプチャが保存されました",
                                 "キャプチャが保存されました",
                                 CaptureSaveController.this.getWindow());
@@ -131,7 +131,7 @@ public class CaptureSaveController extends WindowController {
                         super.failed();
                         Throwable t = this.getException();
 
-                        Tools.Conrtols.alert(AlertType.ERROR,
+                        Tools.Controls.alert(AlertType.ERROR,
                                 "キャプチャの保存先に失敗しました",
                                 "キャプチャの保存先に失敗しました",
                                 t,

--- a/src/main/java/logbook/internal/gui/ColumnVisibleController.java
+++ b/src/main/java/logbook/internal/gui/ColumnVisibleController.java
@@ -57,7 +57,7 @@ public class ColumnVisibleController extends WindowController {
         AppConfig.get()
                 .getColumnWidthMap()
                 .remove(this.key);
-        Tools.Conrtols.alert(AlertType.INFORMATION, "列幅をリセット", "列幅がリセットされました。\n再度ウインドウを開いたときに反映されます。",
+        Tools.Controls.alert(AlertType.INFORMATION, "列幅をリセット", "列幅がリセットされました。\n再度ウインドウを開いたときに反映されます。",
                 this.getWindow());
     }
 

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -468,7 +468,7 @@ public class ConfigController extends WindowController {
         this.pluginTable.setItems(this.plugins);
 
         this.toastLocation.getSelectionModel().selectedItemProperty().addListener(
-                (ob, o, n) -> Tools.Conrtols.showNotify(null, "確認", "この位置に表示されます。", Duration.seconds(5), Pos.valueOf(n.getValue())));
+                (ob, o, n) -> Tools.Controls.showNotify(null, "確認", "この位置に表示されます。", Duration.seconds(5), Pos.valueOf(n.getValue())));
 
         this.bouyomiChanInit();
     }
@@ -708,7 +708,7 @@ public class ConfigController extends WindowController {
         if (bouyomichanPath != null) {
             this.bouyomiPath.setText(bouyomichanPath.toString());
         } else {
-            Tools.Conrtols.alert(AlertType.INFORMATION,
+            Tools.Controls.alert(AlertType.INFORMATION,
                     "BouyomiChan.exeが見つかりません",
                     "選択されたフォルダにBouyomiChan.exeが見つかりませんでした。",
                     this.getWindow());

--- a/src/main/java/logbook/internal/gui/CreateItemController.java
+++ b/src/main/java/logbook/internal/gui/CreateItemController.java
@@ -55,6 +55,8 @@ import javafx.scene.control.cell.TreeItemPropertyValueFactory;
 import javafx.scene.image.ImageView;
 import javafx.util.Duration;
 import logbook.bean.AppConfig;
+import logbook.bean.AppViewConfig;
+import logbook.bean.AppViewConfig.CreateItemLogConfig;
 import logbook.bean.SlotitemEquiptype;
 import logbook.bean.SlotitemEquiptypeCollection;
 import logbook.bean.SlotitemMst;
@@ -175,6 +177,7 @@ public class CreateItemController extends WindowController {
             this.group.selectedToggleProperty()
                     .addListener(this::changeType);
             this.setCollect(this.buttonItemRecipe);
+            loadConfig();
             TreeTableTool.setVisible(this.collect, this.getClass() + "#" + "collect");
         } catch (Exception e) {
             LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
@@ -304,10 +307,16 @@ public class CreateItemController extends WindowController {
                                         toList())));
             }
 
-            TreeItem<CreateItemCollect> root = new TreeItem<>();
-            root.setValue(rootCollect);
-            root.setExpanded(true);
-            this.collect.setRoot(root);
+            TreeItem<CreateItemCollect> root = this.collect.getRoot();
+            if (root == null) {
+                root = new TreeItem<>();
+                root.setValue(rootCollect);
+                root.setExpanded(true);
+                this.collect.setRoot(root);
+            } else {
+                this.collect.getRoot().getChildren().clear();
+                this.collect.getRoot().setValue(rootCollect);
+            }
             this.collect.setShowRoot(true);
             this.setUnit(root, count, null, grouping);
             setCount(root);
@@ -428,6 +437,25 @@ public class CreateItemController extends WindowController {
     private void changeType(ObservableValue<? extends Toggle> observable,
             Toggle oldValue, Toggle value) {
         this.setCollect(value);
+        saveConfig();
+    }
+
+    private void loadConfig() {
+        Optional.ofNullable(AppViewConfig.get().getCreateItemLogConfig())
+            .ifPresent(config -> {
+                if (config.getIndex() == 1) {
+                    this.group.selectToggle(this.buttonRecipeItem);
+                }
+            });
+    }
+
+    private void saveConfig() {
+        CreateItemLogConfig config = AppViewConfig.get().getCreateItemLogConfig();
+        if (config == null) {
+            config = new CreateItemLogConfig();
+        }
+        config.setIndex(this.group.getSelectedToggle() == this.buttonItemRecipe ? 0 : 1);
+        AppViewConfig.get().setCreateItemLogConfig(config);
     }
 
     /**

--- a/src/main/java/logbook/internal/gui/CreateItemController.java
+++ b/src/main/java/logbook/internal/gui/CreateItemController.java
@@ -108,6 +108,10 @@ public class CreateItemController extends WindowController {
     @FXML
     private TableView<CreateItem> detail;
 
+    /** 行番号 */
+    @FXML
+    private TableColumn<BattleLogDetail, Integer> row;
+
     /** 日付 */
     @FXML
     private TableColumn<CreateItem, String> date;
@@ -154,6 +158,7 @@ public class CreateItemController extends WindowController {
             this.count.setCellValueFactory(new TreeItemPropertyValueFactory<>("count"));
             this.ratio.setCellValueFactory(new TreeItemPropertyValueFactory<>("ratio"));
 
+            this.row.setCellFactory(TableTool.getRowCountCellFactory());
             this.date.setCellValueFactory(new PropertyValueFactory<>("date"));
             this.item.setCellValueFactory(new PropertyValueFactory<>("item"));
             this.type.setCellValueFactory(new PropertyValueFactory<>("type"));

--- a/src/main/java/logbook/internal/gui/CreateItemController.java
+++ b/src/main/java/logbook/internal/gui/CreateItemController.java
@@ -139,7 +139,7 @@ public class CreateItemController extends WindowController {
             // SplitPaneの分割サイズ
             Timeline x = new Timeline();
             x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-                Tools.Conrtols.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
+                Tools.Controls.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
             }));
             x.play();
             this.detail.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);

--- a/src/main/java/logbook/internal/gui/CreatePacFileController.java
+++ b/src/main/java/logbook/internal/gui/CreatePacFileController.java
@@ -49,13 +49,13 @@ public class CreatePacFileController extends WindowController {
 
                 this.addr.setText("file:///" + file.toURI().toString().replaceFirst("file:/", ""));
 
-                Tools.Conrtols.alert(AlertType.INFORMATION,
+                Tools.Controls.alert(AlertType.INFORMATION,
                         "自動プロキシ構成スクリプトファイル",
                         "自動プロキシ構成スクリプトファイルを生成しました。\n" + "次にブラウザの設定を行って下さい。",
                         this.getWindow());
             }
         } catch (IOException e) {
-            Tools.Conrtols.alert(AlertType.ERROR,
+            Tools.Controls.alert(AlertType.ERROR,
                     "自動プロキシ構成スクリプトファイル",
                     "自動プロキシ構成スクリプトファイルの生成に失敗しました",
                     e,

--- a/src/main/java/logbook/internal/gui/Deck.java
+++ b/src/main/java/logbook/internal/gui/Deck.java
@@ -168,7 +168,7 @@ public class Deck extends WindowController {
     @FXML
     void storeImage(ActionEvent event) {
         if (this.currentDeck.get() != null) {
-            Tools.Conrtols.storeSnapshot(this.deck, "編成記録_" + this.currentDeck.get().getName(), this.getWindow());
+            Tools.Controls.storeSnapshot(this.deck, "編成記録_" + this.currentDeck.get().getName(), this.getWindow());
         }
     }
 

--- a/src/main/java/logbook/internal/gui/ItemAirBaseController.java
+++ b/src/main/java/logbook/internal/gui/ItemAirBaseController.java
@@ -273,7 +273,7 @@ public class ItemAirBaseController extends WindowController {
                         .get(itemId);
 
                 if (mst != null) {
-                    this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Items.itemImage(mst))));
+                    this.setGraphic(Tools.Controls.zoomImage(new ImageView(Items.itemImage(mst))));
                     this.setText(mst.getName());
                 }
             } else {

--- a/src/main/java/logbook/internal/gui/ItemItemController.java
+++ b/src/main/java/logbook/internal/gui/ItemItemController.java
@@ -211,7 +211,7 @@ public class ItemItemController extends WindowController {
             // SplitPaneの分割サイズ
             Timeline x = new Timeline();
             x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-                Tools.Conrtols.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
+                Tools.Controls.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
             }));
             x.play();
             this.filter.expandedProperty().addListener((ob, o, n) -> saveConfig());
@@ -262,10 +262,10 @@ public class ItemItemController extends WindowController {
                 typesPane.setPrefWidth(Integer.MAX_VALUE);
                 typesPane.getChildren().addAll(types);
                 this.typeFilterPane.add(typesPane, 1, row.getAndIncrement());
-                Tools.Conrtols.bindChildCheckBoxes(category, types);
+                Tools.Controls.bindChildCheckBoxes(category, types);
                 category.disabledProperty().addListener((ob, o, n) -> types.forEach(c -> c.setDisable(n)));
             });
-            Tools.Conrtols.bindChildCheckBoxes(this.allTypes, categoryCheckBoxes);
+            Tools.Controls.bindChildCheckBoxes(this.allTypes, categoryCheckBoxes);
             this.typeFilter.selectedProperty().addListener(this::filterAction);
             this.typeFilter.selectedProperty().addListener((ob, o, n) -> {
                 categoryCheckBoxes.forEach(c -> c.setDisable(!n));
@@ -436,7 +436,7 @@ public class ItemItemController extends WindowController {
                         .get(itemId);
 
                 if (mst != null) {
-                    this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Items.itemImage(mst))));
+                    this.setGraphic(Tools.Controls.zoomImage(new ImageView(Items.itemImage(mst))));
                     this.setText(mst.getName());
                 }
             } else {
@@ -497,7 +497,7 @@ public class ItemItemController extends WindowController {
         protected void updateItem(Ship ship, boolean empty) {
             super.updateItem(ship, empty);
             if (!empty) {
-                this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
+                this.setGraphic(Tools.Controls.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
                 if (ship != null) {
                     this.setText(Ships.toName(ship));
                 } else {

--- a/src/main/java/logbook/internal/gui/MainController.java
+++ b/src/main/java/logbook/internal/gui/MainController.java
@@ -440,7 +440,7 @@ public class MainController extends WindowController {
     private void pushNotifyMission(DeckPort port) {
         if (AppConfig.get().isUseToast()) {
             String message = Messages.getString("mission.complete", port.getName()); //$NON-NLS-1$
-            Tools.Conrtols.showNotify(null, "遠征完了", message);
+            Tools.Controls.showNotify(null, "遠征完了", message);
         }
         if (AppConfig.get().isUseSound()) {
             this.soundNotify(Paths.get(AppConfig.get().getMissionSoundDir()));
@@ -495,7 +495,7 @@ public class MainController extends WindowController {
 
             ImageView img = new ImageView(Ships.shipWithItemImage(ship));
 
-            Tools.Conrtols.showNotify(img, "修復完了", message);
+            Tools.Controls.showNotify(img, "修復完了", message);
         }
         if (AppConfig.get().isUseSound()) {
             this.soundNotify(Paths.get(AppConfig.get().getNdockSoundDir()));

--- a/src/main/java/logbook/internal/gui/MainMenuController.java
+++ b/src/main/java/logbook/internal/gui/MainMenuController.java
@@ -115,7 +115,7 @@ public class MainMenuController extends WindowController {
                             ((BattleDetail) c).setData(sendlog);
                         }, null);
             } else {
-                Tools.Conrtols.alert(AlertType.INFORMATION, "現在の戦闘", "戦闘のデータがありません", this.parentController.getWindow());
+                Tools.Controls.alert(AlertType.INFORMATION, "現在の戦闘", "戦闘のデータがありません", this.parentController.getWindow());
             }
         } catch (Exception ex) {
             LoggerHolder.get().error("詳細の表示に失敗しました", ex);
@@ -139,7 +139,7 @@ public class MainMenuController extends WindowController {
                             ((BattleDetail) c).setData(sendlog);
                         }, null);
             } else {
-                Tools.Conrtols.alert(AlertType.INFORMATION, "演習詳細", "演習のデータがありません", this.parentController.getWindow());
+                Tools.Controls.alert(AlertType.INFORMATION, "演習詳細", "演習のデータがありません", this.parentController.getWindow());
             }
         } catch (Exception ex) {
             LoggerHolder.get().error("詳細の表示に失敗しました", ex);

--- a/src/main/java/logbook/internal/gui/MissionLogController.java
+++ b/src/main/java/logbook/internal/gui/MissionLogController.java
@@ -83,6 +83,10 @@ public class MissionLogController extends WindowController {
     @FXML
     private TableView<MissionLogDetail> detail;
 
+    /** 行番号 */
+    @FXML
+    private TableColumn<BattleLogDetail, Integer> row;
+
     /** 日付 */
     @FXML
     private TableColumn<MissionLogDetail, String> date;
@@ -183,6 +187,7 @@ public class MissionLogController extends WindowController {
         this.detail.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         this.detail.setOnKeyPressed(TableTool::defaultOnKeyPressedHandler);
 
+        this.row.setCellFactory(TableTool.getRowCountCellFactory());
         this.date.setCellValueFactory(new PropertyValueFactory<>("date"));
         this.name.setCellValueFactory(new PropertyValueFactory<>("name"));
         this.result.setCellValueFactory(new PropertyValueFactory<>("result"));

--- a/src/main/java/logbook/internal/gui/MissionLogController.java
+++ b/src/main/java/logbook/internal/gui/MissionLogController.java
@@ -162,9 +162,9 @@ public class MissionLogController extends WindowController {
         // SplitPaneの分割サイズ
         Timeline x = new Timeline();
         x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-            Tools.Conrtols.setSplitWidth(this.splitPane1, this.getClass() + "#" + "splitPane1");
-            Tools.Conrtols.setSplitWidth(this.splitPane2, this.getClass() + "#" + "splitPane2");
-            Tools.Conrtols.setSplitWidth(this.splitPane3, this.getClass() + "#" + "splitPane3");
+            Tools.Controls.setSplitWidth(this.splitPane1, this.getClass() + "#" + "splitPane1");
+            Tools.Controls.setSplitWidth(this.splitPane2, this.getClass() + "#" + "splitPane2");
+            Tools.Controls.setSplitWidth(this.splitPane3, this.getClass() + "#" + "splitPane3");
         }));
         x.play();
 

--- a/src/main/java/logbook/internal/gui/RequireNdockController.java
+++ b/src/main/java/logbook/internal/gui/RequireNdockController.java
@@ -235,7 +235,7 @@ public class RequireNdockController extends WindowController {
             super.updateItem(ship, empty);
 
             if (!empty) {
-                this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
+                this.setGraphic(Tools.Controls.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
                 this.setText(Ships.shipMst(ship)
                         .map(ShipMst::getName)
                         .orElse(""));

--- a/src/main/java/logbook/internal/gui/ResourceChartController.java
+++ b/src/main/java/logbook/internal/gui/ResourceChartController.java
@@ -172,7 +172,7 @@ public class ResourceChartController extends WindowController {
         // SplitPaneの分割サイズ
         Timeline x = new Timeline();
         x.getKeyFrames().add(new KeyFrame(Duration.millis(1), (e) -> {
-            Tools.Conrtols.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
+            Tools.Controls.setSplitWidth(this.splitPane, this.getClass() + "#" + "splitPane");
         }));
         x.play();
         // 資材ログのテーブル列をバインド

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -645,7 +645,7 @@ public class ShipTablePane extends VBox {
         if (this.table.getSelectionModel()
                 .getSelectedItems()
                 .isEmpty()) {
-            Tools.Conrtols.alert(AlertType.INFORMATION,
+            Tools.Controls.alert(AlertType.INFORMATION,
                     "艦娘が選ばれていません",
                     "ラベルを追加する艦娘を選択してください",
                     this.getScene().getWindow());
@@ -692,7 +692,7 @@ public class ShipTablePane extends VBox {
         if (this.table.getSelectionModel()
                 .getSelectedItems()
                 .isEmpty()) {
-            Tools.Conrtols.alert(AlertType.INFORMATION,
+            Tools.Controls.alert(AlertType.INFORMATION,
                     "艦娘が選ばれていません",
                     "ラベルを除去する艦娘を選択してください",
                     this.getScene().getWindow());
@@ -1027,7 +1027,7 @@ public class ShipTablePane extends VBox {
                 if (AppConfig.get().isHideShipImageFromShipTablePane()) {
                     this.setGraphic(null);
                 } else {
-                    this.setGraphic(Tools.Conrtols.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
+                    this.setGraphic(Tools.Controls.zoomImage(new ImageView(Ships.shipWithItemImage(ship))));
                 }
                 this.setText(Ships.shipMst(ship)
                         .map(ShipMst::getName)

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -44,7 +44,6 @@ import javafx.scene.control.Labeled;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputDialog;
@@ -455,21 +454,7 @@ public class ShipTablePane extends VBox {
             this.missionValue.selectedProperty().addListener(this::filterAction);
 
             // カラムとオブジェクトのバインド
-            this.row.setCellFactory(e -> {
-                TableCell<ShipItem, Integer> cell = new TableCell<ShipItem, Integer>() {
-                    @Override
-                    protected void updateItem(Integer item, boolean empty) {
-                        super.updateItem(item, empty);
-                        if (!empty) {
-                            TableRow<?> currentRow = this.getTableRow();
-                            this.setText(Integer.toString(currentRow.getIndex() + 1));
-                        } else {
-                            this.setText(null);
-                        }
-                    }
-                };
-                return cell;
-            });
+            this.row.setCellFactory(TableTool.getRowCountCellFactory());
             this.id.setCellValueFactory(new PropertyValueFactory<>("id"));
             this.fleet.setCellValueFactory(new PropertyValueFactory<>("fleet"));
             this.ship.setCellValueFactory(new PropertyValueFactory<>("ship"));

--- a/src/main/java/logbook/internal/gui/StatisticsPane.java
+++ b/src/main/java/logbook/internal/gui/StatisticsPane.java
@@ -90,7 +90,7 @@ public class StatisticsPane extends VBox {
      */
     @FXML
     void storeImageAction(ActionEvent event) {
-        Tools.Conrtols.storeSnapshot(this.content, "統計情報", this.content.getScene().getWindow());
+        Tools.Controls.storeSnapshot(this.content, "統計情報", this.content.getScene().getWindow());
     }
 
     /**

--- a/src/main/java/logbook/internal/gui/SuggestSupport.java
+++ b/src/main/java/logbook/internal/gui/SuggestSupport.java
@@ -76,7 +76,7 @@ public class SuggestSupport implements Callback<ISuggestionRequest, Collection<S
             return this.values;
         } else {
             return this.values.stream()
-                    .filter(e -> predicate.test(e, text))
+                    .filter(e -> this.predicate.test(e, text))
                     .collect(Collectors.toList());
         }
     }

--- a/src/main/java/logbook/internal/gui/TableTool.java
+++ b/src/main/java/logbook/internal/gui/TableTool.java
@@ -3,10 +3,14 @@ package logbook.internal.gui;
 import java.io.IOException;
 import java.util.List;
 
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+import javafx.util.Callback;
 
 /**
  * TableViewに関係するメソッドを集めたクラス
@@ -95,4 +99,21 @@ class TableTool {
         Tools.Tables.setSortOrder(table, key);
     }
 
+    static <T> Callback<TableColumn<T, Integer>, TableCell<T, Integer>> getRowCountCellFactory() {
+        return e -> {
+            TableCell<T, Integer> cell = new TableCell<T, Integer>() {
+                @Override
+                protected void updateItem(Integer item, boolean empty) {
+                    super.updateItem(item, empty);
+                    if (!empty) {
+                        TableRow<?> currentRow = this.getTableRow();
+                        this.setText(Integer.toString(currentRow.getIndex() + 1));
+                    } else {
+                        this.setText(null);
+                    }
+                }
+            };
+            return cell;
+        };
+    }
 }

--- a/src/main/java/logbook/internal/gui/Tools.java
+++ b/src/main/java/logbook/internal/gui/Tools.java
@@ -151,7 +151,7 @@ public class Tools {
      * misc
      *
      */
-    public static class Conrtols {
+    public static class Controls {
 
         /**
          * ノードの内容をPNGファイルとして出力します

--- a/src/main/resources/logbook/gui/battlelog.fxml
+++ b/src/main/resources/logbook/gui/battlelog.fxml
@@ -66,6 +66,7 @@
                   </TitledPane>
                   <TableView fx:id="detail" VBox.vgrow="ALWAYS">
                     <columns>
+                      <TableColumn fx:id="row" prefWidth="50.0" sortable="false" text="行番号" />
                       <TableColumn fx:id="date" prefWidth="150.0" text="日付" />
                       <TableColumn fx:id="area" prefWidth="130.0" text="海域" />
                       <TableColumn fx:id="cell" prefWidth="40.0" text="マス" />

--- a/src/main/resources/logbook/gui/battlelog.fxml
+++ b/src/main/resources/logbook/gui/battlelog.fxml
@@ -42,6 +42,7 @@
                         <ContextMenu>
                           <items>
                               <MenuItem mnemonicParsing="false" onAction="#addUnitAction" text="集計の追加" />
+                              <MenuItem fx:id="removeUnitMenu" mnemonicParsing="false" onAction="#removeUnitAction" text="集計の削除"  disable="true" />
                               <MenuItem mnemonicParsing="false" onAction="#reloadAction" text="更新">
                                  <accelerator>
                                     <KeyCodeCombination alt="UP" code="F5" control="UP" meta="UP" shift="UP" shortcut="ANY" />
@@ -53,7 +54,8 @@
                   </TreeTableView>
                    <ToolBar>
                      <Button mnemonicParsing="false" onAction="#addUnitAction" text="集計の追加" />
-                       <Button mnemonicParsing="false" onAction="#reloadAction" text="更新(F5)" />
+                     <Button fx:id="removeUnitButton" mnemonicParsing="false" onAction="#removeUnitAction" text="集計の削除"  disable="true" />
+                     <Button mnemonicParsing="false" onAction="#reloadAction" text="更新(F5)" />
                    </ToolBar>
                </children>
             </VBox>

--- a/src/main/resources/logbook/gui/createitemlog.fxml
+++ b/src/main/resources/logbook/gui/createitemlog.fxml
@@ -42,6 +42,7 @@
                <children>
                   <TableView fx:id="detail" VBox.vgrow="ALWAYS">
                      <columns>
+                        <TableColumn fx:id="row" prefWidth="50.0" sortable="false" text="行番号" />
                         <TableColumn fx:id="date" prefWidth="150.0" text="日付" />
                         <TableColumn fx:id="item" prefWidth="120.0" text="開発装備" />
                         <TableColumn fx:id="type" prefWidth="100.0" text="種別" />

--- a/src/main/resources/logbook/gui/missionlog.fxml
+++ b/src/main/resources/logbook/gui/missionlog.fxml
@@ -55,6 +55,7 @@
                         </SplitPane>
                         <TableView fx:id="detail">
                            <columns>
+                              <TableColumn fx:id="row" prefWidth="50.0" sortable="false" text="行番号" />
                               <TableColumn fx:id="date" prefWidth="150.0" text="日付" />
                               <TableColumn fx:id="name" prefWidth="110.0" text="遠征名" />
                               <TableColumn fx:id="result" prefWidth="55.0" text="結果" />

--- a/src/main/resources/logbook/gui/resource_chart.fxml
+++ b/src/main/resources/logbook/gui/resource_chart.fxml
@@ -4,6 +4,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.chart.LineChart?>
 <?import javafx.scene.chart.NumberAxis?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.ContextMenu?>
@@ -23,7 +24,7 @@
          <items>
             <VBox>
                <children>
-                  <FlowPane>
+                  <FlowPane hgap="5">
                      <children>
                         <Label text="期間" />
                         <ChoiceBox fx:id="term" prefWidth="100.0" />
@@ -31,12 +32,13 @@
                         <DatePicker fx:id="from" onAction="#change" prefWidth="120.0" />
                         <Label text="終了" />
                         <DatePicker fx:id="to" onAction="#change" prefWidth="120.0" />
+                        <Button text="今日" onAction="#today" />
                      </children>
                      <padding>
                         <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
                      </padding>
                   </FlowPane>
-                  <FlowPane>
+                  <FlowPane hgap="5">
                      <children>
                         <CheckBox fx:id="fuel" mnemonicParsing="false" onAction="#change" selected="true" text="燃料" />
                         <CheckBox fx:id="ammo" mnemonicParsing="false" onAction="#change" selected="true" text="弾薬" />


### PR DESCRIPTION
#### 変更内容
種々の統計ビューについて改善を行った。
- 戦闘ログ・遠征ログ・開発ログのテーブルに行番号を表示
- 戦闘ログで集計を保存（保存するようになったため削除メニューも追加）
- 開発ログでのタブ状態の保持
- 資材チャートの状態保持（保持するようになったため現在に戻すボタンも追加）

#### 関連するIssue
sanaehirotaka/logbook-kai#165
