### PR TITLE
キャプチャービューの改善

### DIFF
--- a/src/main/java/logbook/api/ApiGetMemberMapinfo.java
+++ b/src/main/java/logbook/api/ApiGetMemberMapinfo.java
@@ -30,6 +30,7 @@ public class ApiGetMemberMapinfo implements APIListenerSpi {
             } else {
                 mapinfo.getAirBase().clear();
             }
+            mapinfo.setLastModified(System.currentTimeMillis());
         }
     }
 

--- a/src/main/java/logbook/bean/AppViewConfig.java
+++ b/src/main/java/logbook/bean/AppViewConfig.java
@@ -2,6 +2,7 @@ package logbook.bean;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -24,6 +25,8 @@ public class AppViewConfig {
     private CreateItemLogConfig createItemLogConfig;
 
     private ResourceChartConfig resourceChartConfig;
+
+    private CaptureConfig captureConfig;
 
     @Data
     public static class BattleLogConfig {
@@ -58,6 +61,21 @@ public class AppViewConfig {
         private boolean research;
         private boolean improve;
         private boolean forceZero;
+    }
+
+    @Data
+    @JsonInclude(Include.NON_DEFAULT)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CaptureConfig {
+        private Bounds bounds;
+
+        @Data
+        public static class Bounds {
+            private int x;
+            private int y;
+            private int width;
+            private int height;
+        }
     }
 
     /**

--- a/src/main/java/logbook/bean/Mapinfo.java
+++ b/src/main/java/logbook/bean/Mapinfo.java
@@ -26,6 +26,9 @@ public class Mapinfo implements Serializable {
     /** api_air_base */
     private List<AirBase> airBase = new ArrayList<>();
 
+    /** 最終更新時刻 */
+    private long lastModified;
+
     /**
      * api_map_info
      */

--- a/src/main/resources/logbook/gui/capture.fxml
+++ b/src/main/resources/logbook/gui/capture.fxml
@@ -63,6 +63,7 @@
             </Button>
             <Button fx:id="save" mnemonicParsing="false" onAction="#save" text="保存" />
             <CheckBox fx:id="direct" mnemonicParsing="false" text="直接保存" />
+            <CheckBox fx:id="autoBattleCapture" mnemonicParsing="false" text="出撃と連動" disable="true"/>
          </items>
       </ToolBar>
       <HBox alignment="CENTER_LEFT">


### PR DESCRIPTION
#### 変更内容
キャプチャビューの改善を行う。

一つ目は自動でゲーム画面が検出できなかった場合、前回自動または手動で設定したゲーム画面の座標を初期値として入れるようにした。これにより手動の場合毎回範囲指定をする必要がなくなる。

二つ目に出撃連動オプションを実装した。動画を選んだ時にこのオプションを指定しておくと、海域を表示したころ（母港から「出撃」を選び次の画面で「出撃」を選んだころ）に自動的に録画が開始され、その後出撃して母港に帰投するか、出撃せずに90秒経過した場合に自動的に録画を停止する。海域の表示をトリガーにしているのは、出撃のAPIをトリガーにしてしまうとそのAPI呼び出しは出撃のボタンを押して画面が変わってから呼ばれるため少し映像の頭が切れてしまうので、その直前のAPI呼び出しということで海域の表示を選んでいる。

#### 関連するIssue
sanaehirotaka/logbook-kai#151

