### PR TITLE
遠征時の艦載機による対潜値計算の補正 Sdk0815#16

### DIFF
--- a/src/main/java/logbook/bean/MissionCondition.java
+++ b/src/main/java/logbook/bean/MissionCondition.java
@@ -160,7 +160,9 @@ public class MissionCondition implements TestAllPredicate<List<Ship>> {
             current = this.fleetStatus(ships, ship -> ship.getKaryoku().get(0));
         }
         if ("対潜".equals(this.countType)) {
-            current = this.fleetStatus(ships , ship -> Ships.getTaisen(ship) + Ships.sumItemParam(ship, SlotitemMst::getTais, true));
+            // 遠征のときは艦載機の対潜値は複雑な式となるので、最小見積もりとして0.65倍する（ことによって false positive をなくす）
+            current = this.fleetStatus(ships , ship -> Ships.getTaisen(ship)
+                    + Ships.sumItemParam(ship, (item) -> Items.isAircraft(item) ? (int)(item.getTais()*0.65) : item.getTais(), true));
         }
         if ("対空".equals(this.countType)) {
             current = this.fleetStatus(ships, ship -> ship.getTaiku().get(0));


### PR DESCRIPTION
#### 問題解析
Issue #16 に書かれている通り、要求対潜値330の遠征に331で遠征したところ失敗となった模様。いろいろ調査したところ、艦載機の対潜値はそのままの値ではなく、搭載数の影響も受けるようで、以前も sanaehirotaka#225 で搭載数0の場合はそもそも対潜値が加算されないはずなのに logbook-kai 上は加算されていた、という問題もあった。今回搭載数は0ではなかったが、調査によると搭載数がある程度少ない場合は装備に表示されている対潜値より低くなることがあるようで、実際搭載数が1や2の場合は装備の対戦値の0.65倍（小数点以下切り捨て）となり、それ以上の搭載数である場合も搭載数や改修値などに影響されることがわかった。今回は艦これの画面上の対潜値（＝装備の対潜値）は8だったが、艦載機によるものだったため実際は8x0.65=5となり、対潜値328<330なため失敗となったと考えられる。

#### 変更内容
複雑な計算式はそもそも有志による検証で導かれていて艦これのUI上からは確認の方法のないものとなっている。従って正確な計算式を実装することは行わず可能な限り低く見積もることで false positive（「成功」と出ているのに失敗する今回のようなケース）を防ぎ、false negative（「失敗」と出ているのに成功する）ケースはほぼ害がないと判断して容認することにする。具体的には艦載機が1以上の場合は一律で0.65掛けを行うことにする。

#### 関連するIssue
#16

