### PR TITLE
アイテム一覧を表示

### DIFF
--- a/src/main/java/logbook/api/ApiGetMemberMaterial.java
+++ b/src/main/java/logbook/api/ApiGetMemberMaterial.java
@@ -26,10 +26,11 @@ public class ApiGetMemberMaterial implements APIListenerSpi {
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
         JsonArray array = json.getJsonArray("api_data");
         if (array != null) {
+            Map<Integer, Material> material = JsonHelper.toMap(array, Material::getId, Material::toMaterial);
+            AppCondition.get().setMaterial(material);
             Duration duration = Duration.ofMillis(System.currentTimeMillis() - AppCondition.get()
                     .getWroteMaterialLogLast());
             if (duration.compareTo(Duration.ofSeconds(AppConfig.get().getMaterialLogInterval())) >= 0) {
-                Map<Integer, Material> material = JsonHelper.toMap(array, Material::getId, Material::toMaterial);
                 LogWriter.getInstance(MaterialLogFormat::new)
                         .write(material);
                 AppCondition.get()

--- a/src/main/java/logbook/api/ApiGetMemberRequireInfo.java
+++ b/src/main/java/logbook/api/ApiGetMemberRequireInfo.java
@@ -6,6 +6,8 @@ import javax.json.JsonObject;
 import logbook.bean.Basic;
 import logbook.bean.SlotItem;
 import logbook.bean.SlotItemCollection;
+import logbook.bean.Useitem;
+import logbook.bean.UseitemCollection;
 import logbook.internal.JsonHelper;
 import logbook.proxy.RequestMetaData;
 import logbook.proxy.ResponseMetaData;
@@ -23,6 +25,7 @@ public class ApiGetMemberRequireInfo implements APIListenerSpi {
         if (data != null) {
             this.apiBasic(data.getJsonObject("api_basic"));
             this.apiSlotItem(data.getJsonArray("api_slot_item"));
+            this.apiUseitem(data.getJsonArray("api_useitem"));
         }
     }
 
@@ -43,6 +46,16 @@ public class ApiGetMemberRequireInfo implements APIListenerSpi {
     private void apiSlotItem(JsonArray array) {
         SlotItemCollection.get()
                 .setSlotitemMap(JsonHelper.toMap(array, SlotItem::getId, SlotItem::toSlotItem));
+    }
+
+    /**
+     * api_data.api_useitem
+     *
+     * @param array api_useitem
+     */
+    private void apiUseitem(JsonArray array) {
+        UseitemCollection.get()
+                .setUseitemMap(JsonHelper.toMap(array, Useitem::getId, Useitem::toUseitem));
     }
 
 }

--- a/src/main/java/logbook/api/ApiGetMemberUseitem.java
+++ b/src/main/java/logbook/api/ApiGetMemberUseitem.java
@@ -1,0 +1,28 @@
+package logbook.api;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import logbook.bean.Useitem;
+import logbook.bean.UseitemCollection;
+import logbook.internal.JsonHelper;
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * /kcsapi/api_get_member/useitem
+ *
+ */
+@API("/kcsapi/api_get_member/useitem")
+public class ApiGetMemberUseitem implements APIListenerSpi {
+
+    @Override
+    public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
+        JsonArray array = json.getJsonArray("api_data");
+        if (array != null) {
+            UseitemCollection.get()
+                    .setUseitemMap(JsonHelper.toMap(array, Useitem::getId, Useitem::toUseitem));
+        }
+    }
+
+}

--- a/src/main/java/logbook/api/ApiPortPort.java
+++ b/src/main/java/logbook/api/ApiPortPort.java
@@ -156,10 +156,11 @@ public class ApiPortPort implements APIListenerSpi {
      * @param array api_material
      */
     private void apiMaterial(JsonArray array) {
+        Map<Integer, Material> material = JsonHelper.toMap(array, Material::getId, Material::toMaterial);
+        AppCondition.get().setMaterial(material);
         Duration duration = Duration.ofMillis(System.currentTimeMillis() - AppCondition.get()
                 .getWroteMaterialLogLast());
         if (duration.compareTo(Duration.ofSeconds(AppConfig.get().getMaterialLogInterval())) >= 0) {
-            Map<Integer, Material> material = JsonHelper.toMap(array, Material::getId, Material::toMaterial);
             LogWriter.getInstance(MaterialLogFormat::new)
                     .write(material);
             AppCondition.get()

--- a/src/main/java/logbook/api/ApiStart2.java
+++ b/src/main/java/logbook/api/ApiStart2.java
@@ -33,8 +33,8 @@ import logbook.bean.SlotitemMst;
 import logbook.bean.SlotitemMstCollection;
 import logbook.bean.Stype;
 import logbook.bean.StypeCollection;
-import logbook.bean.Useitem;
-import logbook.bean.UseitemCollection;
+import logbook.bean.UseitemMst;
+import logbook.bean.UseitemMstCollection;
 import logbook.internal.Config;
 import logbook.internal.JsonHelper;
 import logbook.internal.LoggerHolder;
@@ -133,8 +133,8 @@ public class ApiStart2 implements APIListenerSpi {
      * @param array api_mst_useitem
      */
     private void apiMstUseitem(JsonArray array) {
-        UseitemCollection.get()
-                .setUseitemMap(JsonHelper.toMap(array, Useitem::getId, Useitem::toMission));
+        UseitemMstCollection.get()
+                .setUseitemMap(JsonHelper.toMap(array, UseitemMst::getId, UseitemMst::toUseitem));
     }
 
     /**

--- a/src/main/java/logbook/bean/AppCondition.java
+++ b/src/main/java/logbook/bean/AppCondition.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import logbook.internal.Config;
@@ -41,6 +42,9 @@ public class AppCondition implements Serializable {
 
     /** 退避艦ID */
     private Set<Integer> escape = new HashSet<>();
+
+    /** 資材状況 */
+    private Map<Integer, Material> material;
 
     /** 最後に資材ログに書き込んだ時間 */
     private long wroteMaterialLogLast = 0;

--- a/src/main/java/logbook/bean/Useitem.java
+++ b/src/main/java/logbook/bean/Useitem.java
@@ -1,0 +1,34 @@
+package logbook.bean;
+
+import java.io.Serializable;
+
+import javax.json.JsonObject;
+
+import logbook.internal.JsonHelper;
+import lombok.Data;
+
+@Data
+public class Useitem implements Serializable {
+
+    private static final long serialVersionUID = 3756342448962760487L;
+
+    /** api_id */
+    private Integer id;
+
+    /** api_count */
+    private Integer count;
+
+    /**
+     * JsonObjectから{@link Useitem}を構築します
+     *
+     * @param json JsonObject
+     * @return {@link Useitem}
+     */
+    public static Useitem toUseitem(JsonObject json) {
+        Useitem bean = new Useitem();
+        JsonHelper.bind(json)
+                .setInteger("api_id", bean::setId)
+                .setInteger("api_count", bean::setCount);
+        return bean;
+    }
+}

--- a/src/main/java/logbook/bean/UseitemCollection.java
+++ b/src/main/java/logbook/bean/UseitemCollection.java
@@ -1,0 +1,34 @@
+package logbook.bean;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import logbook.internal.Config;
+import lombok.Data;
+
+/**
+ * アイテムのコレクション
+ *
+ */
+@Data
+public class UseitemCollection implements Serializable {
+
+    private static final long serialVersionUID = -8478137452548268689L;
+
+    /** アイテム */
+    private Map<Integer, Useitem> useitemMap = new LinkedHashMap<>();
+
+    /**
+     * アプリケーションのデフォルト設定ディレクトリから{@link UseitemCollection}を取得します、
+     * これは次の記述と同等です
+     * <blockquote>
+     *     <code>Config.getDefault().get(UseitemCollection.class, UseitemCollection::new)</code>
+     * </blockquote>
+     *
+     * @return {@link UseitemCollection}
+     */
+    public static UseitemCollection get() {
+        return Config.getDefault().get(UseitemCollection.class, UseitemCollection::new);
+    }
+}

--- a/src/main/java/logbook/bean/UseitemMst.java
+++ b/src/main/java/logbook/bean/UseitemMst.java
@@ -11,7 +11,7 @@ import lombok.Data;
  * api_mst_useitem
  */
 @Data
-public class Useitem implements Serializable {
+public class UseitemMst implements Serializable {
 
     private static final long serialVersionUID = -3290324243327123224L;
 
@@ -27,13 +27,13 @@ public class Useitem implements Serializable {
     }
 
     /**
-     * JsonObjectから{@link Useitem}を構築します
+     * JsonObjectから{@link UseitemMst}を構築します
      *
      * @param json JsonObject
-     * @return {@link Useitem}
+     * @return {@link UseitemMst}
      */
-    public static Useitem toMission(JsonObject json) {
-        Useitem bean = new Useitem();
+    public static UseitemMst toUseitem(JsonObject json) {
+        UseitemMst bean = new UseitemMst();
         JsonHelper.bind(json)
                 .setInteger("api_id", bean::setId)
                 .setString("api_name", bean::setName);

--- a/src/main/java/logbook/bean/UseitemMst.java
+++ b/src/main/java/logbook/bean/UseitemMst.java
@@ -1,6 +1,7 @@
 package logbook.bean;
 
 import java.io.Serializable;
+import java.util.List;
 
 import javax.json.JsonObject;
 
@@ -21,6 +22,9 @@ public class UseitemMst implements Serializable {
     /** api_name */
     private String name;
 
+    /** api_description */
+    private List<String> description;
+
     @Override
     public String toString() {
         return this.name;
@@ -36,7 +40,8 @@ public class UseitemMst implements Serializable {
         UseitemMst bean = new UseitemMst();
         JsonHelper.bind(json)
                 .setInteger("api_id", bean::setId)
-                .setString("api_name", bean::setName);
+                .setString("api_name", bean::setName)
+                .setStringList("api_description", bean::setDescription);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/UseitemMstCollection.java
+++ b/src/main/java/logbook/bean/UseitemMstCollection.java
@@ -12,23 +12,23 @@ import lombok.Data;
  *
  */
 @Data
-public class UseitemCollection implements Serializable {
+public class UseitemMstCollection implements Serializable {
 
     private static final long serialVersionUID = -3813660780247992556L;
 
     /** アイテム */
-    private Map<Integer, Useitem> useitemMap = new LinkedHashMap<>();
+    private Map<Integer, UseitemMst> useitemMap = new LinkedHashMap<>();
 
     /**
-     * アプリケーションのデフォルト設定ディレクトリから{@link UseitemCollection}を取得します、
+     * アプリケーションのデフォルト設定ディレクトリから{@link UseitemMstCollection}を取得します、
      * これは次の記述と同等です
      * <blockquote>
      *     <code>Config.getDefault().get(UseitemCollection.class, UseitemCollection::new)</code>
      * </blockquote>
      *
-     * @return {@link UseitemCollection}
+     * @return {@link UseitemMstCollection}
      */
-    public static UseitemCollection get() {
-        return Config.getDefault().get(UseitemCollection.class, UseitemCollection::new);
+    public static UseitemMstCollection get() {
+        return Config.getDefault().get(UseitemMstCollection.class, UseitemMstCollection::new);
     }
 }

--- a/src/main/java/logbook/internal/gui/MainController.java
+++ b/src/main/java/logbook/internal/gui/MainController.java
@@ -170,6 +170,18 @@ public class MainController extends WindowController {
     }
 
     /**
+     * アイテム一覧
+     * @param e ActionEvent
+     */
+    public void useitems(ActionEvent e) {
+        try {
+            InternalFXMLLoader.showWindow("logbook/gui/useitem.fxml", this.getWindow(), "アイテム一覧");
+        } catch (Exception ex) {
+            LoggerHolder.get().error("アイテム一覧の初期化に失敗しました", ex);
+        }
+    }
+
+    /**
      * 画面の更新
      *
      * @param e

--- a/src/main/java/logbook/internal/gui/MainMenuController.java
+++ b/src/main/java/logbook/internal/gui/MainMenuController.java
@@ -223,6 +223,16 @@ public class MainMenuController extends WindowController {
     }
 
     /**
+     * アイテム一覧
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void useitems(ActionEvent e) {
+        this.parentController.useitems(e);
+    }
+
+    /**
      * お風呂に入りたい艦娘
      *
      * @param e ActionEvent

--- a/src/main/java/logbook/internal/gui/TableTool.java
+++ b/src/main/java/logbook/internal/gui/TableTool.java
@@ -1,6 +1,7 @@
 package logbook.internal.gui;
 
 import java.io.IOException;
+import java.text.NumberFormat;
 import java.util.List;
 
 import javafx.scene.control.TableCell;
@@ -114,6 +115,24 @@ class TableTool {
                 }
             };
             return cell;
+        };
+    }
+    
+    static Callback<TableColumn<UseitemItem, Integer>, TableCell<UseitemItem, Integer>> createIntegerFormattedCellFactory() {
+        final NumberFormat format = NumberFormat.getIntegerInstance();
+        return new Callback<TableColumn<UseitemItem,Integer>, TableCell<UseitemItem,Integer>>() {
+            @Override
+            public TableCell<UseitemItem, Integer> call(TableColumn<UseitemItem, Integer> param) {
+                return new TableCell<UseitemItem, Integer>() {
+                    @Override
+                    protected void updateItem(Integer item, boolean empty) {
+                        super.updateItem(item, empty);
+                        if (item != null) {
+                            setText(format.format(item));
+                        }
+                    }
+                };
+            }
         };
     }
 }

--- a/src/main/java/logbook/internal/gui/UseitemController.java
+++ b/src/main/java/logbook/internal/gui/UseitemController.java
@@ -1,0 +1,151 @@
+package logbook.internal.gui;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javafx.animation.Timeline;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.stage.WindowEvent;
+import logbook.bean.UseitemMstCollection;
+import logbook.internal.LoggerHolder;
+
+/**
+ * アイテム一覧のコントローラー
+ *
+ */
+public class UseitemController extends WindowController {
+
+    /** 持ってないアイテムも出す */
+    @FXML
+    private CheckBox includeEmpty;
+
+    @FXML
+    private TableView<UseitemItem> table;
+
+    /** 行番号 */
+    @FXML
+    private TableColumn<UseitemItem, Integer> row;
+
+    /** ID */
+    @FXML
+    private TableColumn<UseitemItem, Integer> id;
+
+    /** 名前 */
+    @FXML
+    private TableColumn<UseitemItem, String> name;
+
+    /** 個数 */
+    @FXML
+    private TableColumn<UseitemItem, Integer> count;
+
+    /** 説明 */
+    @FXML
+    private TableColumn<UseitemItem, String> description;
+
+    private ObservableList<UseitemItem> items = FXCollections.observableArrayList();
+
+    private int itemsHashCode;
+
+    private Timeline timeline;
+
+    @FXML
+    void initialize() {
+        TableTool.setVisible(this.table, this.getClass().toString() + "#" + "table");
+
+        // カラムとオブジェクトのバインド
+        this.row.setCellFactory(TableTool.getRowCountCellFactory());
+        this.id.setCellValueFactory(new PropertyValueFactory<>("id"));
+        this.name.setCellValueFactory(new PropertyValueFactory<>("name"));
+        this.count.setCellValueFactory(new PropertyValueFactory<>("count"));
+        this.count.setCellFactory(TableTool.createIntegerFormattedCellFactory());
+        this.description.setCellValueFactory(new PropertyValueFactory<>("description"));
+
+        SortedList<UseitemItem> sortedList = new SortedList<>(this.items);
+        this.table.setItems(sortedList);
+        sortedList.comparatorProperty().bind(this.table.comparatorProperty());
+        this.table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+        this.table.setOnKeyPressed(TableTool::defaultOnKeyPressedHandler);
+
+        this.update(null);
+    }
+
+    /**
+     * 画面の更新
+     *
+     * @param e ActionEvent
+     */
+    @FXML
+    void update(ActionEvent e) {
+        List<UseitemItem> items = UseitemMstCollection.get().getUseitemMap().values().stream()
+                .map(UseitemItem::toUseitemItem)
+                .filter(this::filter)
+                .sorted(Comparator.comparing(UseitemItem::getId))
+                .collect(Collectors.toList());
+        if (this.itemsHashCode != items.hashCode()) {
+            this.items.clear();
+            this.items.addAll(items);
+            this.itemsHashCode = items.hashCode();
+        }
+    }
+
+    /**
+     * クリップボードにコピー
+     */
+    @FXML
+    void copy() {
+        TableTool.selectionCopy(this.table);
+    }
+
+    /**
+     * すべてを選択
+     */
+    @FXML
+    void selectAll() {
+        TableTool.selectAll(this.table);
+    }
+
+    /**
+     * テーブル列の表示・非表示の設定
+     */
+    @FXML
+    void columnVisible() {
+        try {
+            TableTool.showVisibleSetting(this.table, this.getClass().toString() + "#" + "table",
+                    this.getWindow());
+        } catch (Exception e) {
+            LoggerHolder.get().error("FXMLの初期化に失敗しました", e);
+        }
+    }
+
+    /**
+     * フィルター
+     * @param item アイテム
+     * @return フィルタ結果
+     */
+    private boolean filter(UseitemItem item) {
+        boolean result = item.getName() != null && item.getName().length() > 0;
+
+        if (result && !this.includeEmpty.isSelected()) {
+            result &= Optional.ofNullable(item.getCount()).filter(c -> c.intValue() > 0).orElse(0) > 0;
+        }
+        return result;
+    }
+
+    @Override
+    protected void onWindowHidden(WindowEvent e) {
+        if (this.timeline != null) {
+            this.timeline.stop();
+        }
+    }
+}

--- a/src/main/java/logbook/internal/gui/UseitemItem.java
+++ b/src/main/java/logbook/internal/gui/UseitemItem.java
@@ -1,0 +1,154 @@
+package logbook.internal.gui;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import logbook.bean.AppCondition;
+import logbook.bean.Basic;
+import logbook.bean.Material;
+import logbook.bean.SlotItemCollection;
+import logbook.bean.Useitem;
+import logbook.bean.UseitemCollection;
+import logbook.bean.UseitemMst;
+
+/**
+ * アイテム
+ */
+public class UseitemItem {
+
+    /** ID */
+    private IntegerProperty id = new SimpleIntegerProperty();
+
+    /** 名前 */
+    private StringProperty name = new SimpleStringProperty();
+
+    /** 個数 */
+    private IntegerProperty count = new SimpleIntegerProperty();
+
+    /** 説明 */
+    private StringProperty description = new SimpleStringProperty();
+
+    public Integer getId() {
+        return this.id.get();
+    }
+
+    public void setId(Integer id) {
+        this.id.setValue(id);
+    }
+
+    public IntegerProperty idProperty() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name.get();
+    }
+
+    public void setName(String name) {
+        this.name.setValue(name);
+    }
+
+    public StringProperty nameProperty() {
+        return this.name;
+    }
+
+    public Integer getCount() {
+        return this.count.get();
+    }
+
+    public void setCount(Integer count) {
+        this.count.setValue(count);
+    }
+
+    public IntegerProperty countProperty() {
+        return this.count;
+    }
+
+    public String getDescription() {
+        return this.description.get();
+    }
+
+    public void setDescription(String description) {
+        this.description.setValue(description);
+    }
+
+    public StringProperty descriptionProperty() {
+        return this.description;
+    }
+
+    /** Useitem API での ID と material ID のマッピング */
+    private static final Map<Integer, Integer> MATERIALS_MAP = new HashMap<>();
+    
+    /** Useitem API での ID と Slotitem ID のマッピング */
+    private static final Map<Integer, Integer> ITEMS_MAP = new HashMap<>();
+
+    static {
+        MATERIALS_MAP.put(1, 6);    // バケツ
+        MATERIALS_MAP.put(2, 5);    // バーナー
+        MATERIALS_MAP.put(3, 7);    // 釘
+        MATERIALS_MAP.put(4, 8);    // ネジ
+        MATERIALS_MAP.put(31, 1);   // 燃料
+        MATERIALS_MAP.put(32, 2);   // 弾薬
+        MATERIALS_MAP.put(33, 3);   // 鋼材
+        MATERIALS_MAP.put(34, 4);   // ボーキ
+        ITEMS_MAP.put(50, 42);  // ダメコン
+        ITEMS_MAP.put(51, 43);  // 女神
+        ITEMS_MAP.put(66, 145);  // おにぎり
+        ITEMS_MAP.put(67, 146);  // 洋上補給
+        ITEMS_MAP.put(69, 150);  // 秋刀魚の缶詰
+        ITEMS_MAP.put(76, 241);  // 特別なおにぎり
+    }
+    
+    public static UseitemItem toUseitemItem(UseitemMst item) {
+        UseitemItem ret = new UseitemItem();
+        ret.setId(item.getId());
+        ret.setName(item.getName());
+        if (item.getDescription().size() > 0) {
+            StringBuilder sb = new StringBuilder(256);
+            sb.append(item.getDescription().get(0).replaceAll("<br>", ""));
+            if (item.getDescription().size() > 1 && item.getDescription().get(1).trim().length() > 0) {
+                sb.append(" (").append(item.getDescription().get(1)).append(")");
+            }
+            ret.setDescription(sb.toString());
+        }
+        
+        if (MATERIALS_MAP.containsKey(item.getId())) {
+            // 資材系
+            ret.setCount(Optional.ofNullable(MATERIALS_MAP.get(item.getId()))
+                .map(AppCondition.get().getMaterial()::get)
+                .map(Material::getValue)
+                .orElse(0));
+        } else if (item.getId() == 44) {
+            // 家具コインのみ Basic からとる
+            ret.setCount(Basic.get().getFcoin());
+        } else if (ITEMS_MAP.containsKey(item.getId())) {
+            // 装備系
+            final int slotitemId = ITEMS_MAP.get(item.getId());
+            ret.setCount((int)SlotItemCollection.get().getSlotitemMap().values().stream()
+                    .filter(slotitem -> slotitem.getSlotitemId() == slotitemId)
+                    .count());
+        } else {
+            // その他の純粋なアイテム
+            Optional.ofNullable(UseitemCollection.get().getUseitemMap().get(item.getId()))
+                .map(Useitem::getCount)
+                .ifPresent(ret::setCount);
+        }
+        return ret;
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner("\t")
+                .add(Integer.toString(this.id.get()))
+                .add(this.name.get())
+                .add(Optional.ofNullable(this.count.get()).map(c -> Integer.toString(c)).orElse("-"))
+                .add(this.description.get())
+                .toString();
+    }
+}

--- a/src/main/java/logbook/internal/log/BattleResultLogFormat.java
+++ b/src/main/java/logbook/internal/log/BattleResultLogFormat.java
@@ -22,8 +22,8 @@ import logbook.bean.ShipMst;
 import logbook.bean.ShipMstCollection;
 import logbook.bean.SlotitemMst;
 import logbook.bean.SlotitemMstCollection;
-import logbook.bean.Useitem;
-import logbook.bean.UseitemCollection;
+import logbook.bean.UseitemMst;
+import logbook.bean.UseitemMstCollection;
 import logbook.internal.Ships;
 
 /**
@@ -225,8 +225,8 @@ public class BattleResultLogFormat extends LogFormatBase<BattleLog> {
         // ドロップアイテム
         format.ドロップアイテム = Optional.ofNullable(result.getGetUseitem())
                 .map(BattleResult.Useitem::getUseitemId)
-                .map(id -> Optional.ofNullable(UseitemCollection.get().getUseitemMap().get(id)))
-                .map(o -> o.map(Useitem::getName).orElse("不明"))
+                .map(id -> Optional.ofNullable(UseitemMstCollection.get().getUseitemMap().get(id)))
+                .map(o -> o.map(UseitemMst::getName).orElse("不明"))
                 .orElse("");
         // 経験値
         format.艦娘経験値 = Integer.toString(result.getGetShipExp().stream()

--- a/src/main/java/logbook/internal/log/MissionResultLogFormat.java
+++ b/src/main/java/logbook/internal/log/MissionResultLogFormat.java
@@ -5,8 +5,8 @@ import java.util.Optional;
 import java.util.StringJoiner;
 
 import logbook.bean.MissionResult;
-import logbook.bean.Useitem;
-import logbook.bean.UseitemCollection;
+import logbook.bean.UseitemMst;
+import logbook.bean.UseitemMstCollection;
 
 /**
  * 遠征報告書
@@ -64,17 +64,17 @@ public class MissionResultLogFormat extends LogFormatBase<MissionResult> {
         // ボーキ
         joiner.add(result.getGetMaterial().get(3).toString());
 
-        Map<Integer, Useitem> useitemMap = UseitemCollection.get().getUseitemMap();
+        Map<Integer, UseitemMst> useitemMap = UseitemMstCollection.get().getUseitemMap();
         // アイテム1名前
         // アイテム1個数
         if (result.getGetItem1() != null) {
-            Optional<Useitem> item;
+            Optional<UseitemMst> item;
             if (result.getUseitemFlag().get(0) != 4) {
                 item = Optional.ofNullable(useitemMap.get(result.getUseitemFlag().get(0)));
             } else {
                 item = Optional.ofNullable(useitemMap.get(result.getGetItem1().getUseitemId()));
             }
-            joiner.add(item.map(Useitem::getName).orElse(""));
+            joiner.add(item.map(UseitemMst::getName).orElse(""));
             joiner.add(result.getGetItem1().getUseitemCount().toString());
         } else {
             joiner.add("");
@@ -83,13 +83,13 @@ public class MissionResultLogFormat extends LogFormatBase<MissionResult> {
         // アイテム2名前
         // アイテム2個数
         if (result.getGetItem2() != null) {
-            Optional<Useitem> item;
+            Optional<UseitemMst> item;
             if (result.getUseitemFlag().get(1) != 4) {
                 item = Optional.ofNullable(useitemMap.get(result.getUseitemFlag().get(1)));
             } else {
                 item = Optional.ofNullable(useitemMap.get(result.getGetItem2().getUseitemId()));
             }
-            joiner.add(item.map(Useitem::getName).orElse(""));
+            joiner.add(item.map(UseitemMst::getName).orElse(""));
             joiner.add(result.getGetItem2().getUseitemCount().toString());
         } else {
             joiner.add("");

--- a/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
+++ b/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
@@ -11,6 +11,7 @@ logbook.api.ApiGetMemberShip2
 logbook.api.ApiGetMemberShip3
 logbook.api.ApiGetMemberShipDeck
 logbook.api.ApiGetMemberSlotItem
+logbook.api.ApiGetMemberUseitem
 logbook.api.ApiPortPort
 logbook.api.ApiReqAirCorpsSetAction
 logbook.api.ApiReqAirCorpsSetPlane

--- a/src/main/resources/logbook/gui/main_menu.fxml
+++ b/src/main/resources/logbook/gui/main_menu.fxml
@@ -37,6 +37,7 @@
                    <accelerator>
                       <KeyCodeCombination alt="UP" code="S" control="DOWN" meta="UP" shift="UP" shortcut="UP" />
                    </accelerator></MenuItem>
+            <MenuItem mnemonicParsing="false" onAction="#useitems" text="アイテム一覧" />
             <SeparatorMenuItem mnemonicParsing="false" />
             <MenuItem mnemonicParsing="false" onAction="#ndock" text="お風呂に入りたい艦娘">
                    <accelerator>

--- a/src/main/resources/logbook/gui/useitem.fxml
+++ b/src/main/resources/logbook/gui/useitem.fxml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ContextMenu?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.SeparatorMenuItem?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.ToolBar?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="800.0" styleClass="ndockWindow" stylesheets="@application.css" xmlns="http://javafx.com/javafx/8.0.162" xmlns:fx="http://javafx.com/fxml/1" fx:controller="logbook.internal.gui.UseitemController">
+   <children>
+      <ToolBar prefHeight="40.0" prefWidth="200.0">
+         <items>
+            <CheckBox fx:id="includeEmpty" mnemonicParsing="false" onAction="#update" text="持ってないアイテムを表示する" />
+         </items>
+      </ToolBar>
+      <TableView fx:id="table" VBox.vgrow="ALWAYS">
+        <columns>
+          <TableColumn fx:id="row" prefWidth="50.0" sortable="false" text="行番号" />
+          <TableColumn fx:id="id" prefWidth="50.0" text="ID" />
+          <TableColumn fx:id="name" prefWidth="200.0" text="名前" />
+          <TableColumn fx:id="count" prefWidth="50.0" text="個数"  styleClass="align_right"/>
+          <TableColumn fx:id="description" prefWidth="300.0" text="説明" />
+        </columns>
+        <contextMenu>
+           <ContextMenu>
+             <items>
+               <MenuItem mnemonicParsing="false" onAction="#copy" text="クリップボードにコピー" />
+               <MenuItem mnemonicParsing="false" onAction="#selectAll" text="すべてを選択" />
+               <SeparatorMenuItem mnemonicParsing="false" />
+               <MenuItem mnemonicParsing="false" onAction="#columnVisible" text="列の表示・非表示" />
+             </items>
+           </ContextMenu>
+        </contextMenu>
+      </TableView>
+   </children>
+</VBox>


### PR DESCRIPTION
#### 変更内容
報酬選択型の任務で報酬を受け取ろうとした時、その報酬のアイテムを今現在何個持っているのかがわからず、かつ戻るボタンがないため戻るには艦これ自体を再起動しないといけないのが面倒。それを解決する方法を実装した。

Useitem APIによりアイテムの一覧を表示する。実際にはアイテムとして定義されているものの中に資材系（燃料やバケツなど）や装備系（ダメコンやおにぎりなど）も含まれているので、このAPIの値をそのまま出すとこれらは0として表示されてしまう。現状ではそのIDのマッピングが見当たらないのでコード内に保持した。そんなに頻繁に使うビューではないと思われるので、メイン画面にボタンは配置せず、「コマンド」「アイテム一覧」で表示するようにした。

また、本来はそのAPIは1つ以上持っているアイテムについてのみデータを返してくるので、そのまま個数を表示すると持っていないアイテムについては当然表示されない。だがチェックボックスでそれら持っていないアイテムでも定義にあるものは表示するオプションも実装しておいた。

![image](https://user-images.githubusercontent.com/3181895/99790015-d5e2c800-2b66-11eb-9234-d6b97d677866.png)

#### 関連するIssue
N/A

