### PR TITLE
戦闘終了時にデータをディスクに保存する Sdk0815#18

### DIFF
--- a/src/main/java/logbook/api/ApiReqCombinedBattleBattleresult.java
+++ b/src/main/java/logbook/api/ApiReqCombinedBattleBattleresult.java
@@ -20,6 +20,7 @@ import logbook.bean.ShipCollection;
 import logbook.internal.Audios;
 import logbook.internal.BattleLogs;
 import logbook.internal.BouyomiChanUtils;
+import logbook.internal.Config;
 import logbook.internal.Logs;
 import logbook.internal.PhaseState;
 import logbook.internal.BouyomiChanUtils.Type;
@@ -103,5 +104,7 @@ public class ApiReqCombinedBattleBattleresult implements APIListenerSpi {
                 }
             }
         }
+        // 戦闘結果APIの前後は他のAPIが呼ばれることがなくconflictの可能性が低いためデータ保存する
+        Config.getDefault().store();
     }
 }

--- a/src/main/java/logbook/api/ApiReqSortieBattleresult.java
+++ b/src/main/java/logbook/api/ApiReqSortieBattleresult.java
@@ -22,6 +22,7 @@ import logbook.internal.BouyomiChanUtils;
 import logbook.internal.Logs;
 import logbook.internal.PhaseState;
 import logbook.internal.BouyomiChanUtils.Type;
+import logbook.internal.Config;
 import logbook.internal.gui.Tools;
 import logbook.internal.log.BattleResultLogFormat;
 import logbook.internal.log.LogWriter;
@@ -101,5 +102,7 @@ public class ApiReqSortieBattleresult implements APIListenerSpi {
                 }
             }
         }
+        // 戦闘結果APIの前後は他のAPIが呼ばれることがなくconflictの可能性が低いためデータ保存する
+        Config.getDefault().store();
     }
 }


### PR DESCRIPTION
#### 変更内容
今のところ各種データが保存されるタイミングは
- `/kcsapi/api_start2/getData` が処理された時（艦これの起動時）
- logbook-kai の正常終了時
- 設定変更時

の3つになるが、これだと艦これをずっと起動したまま特に設定変更もせずにいた場合、PCのクラッシュ等予期せぬ終了が起こった場合にデータが保存されず、例えば #18 で挙げられているように任務の受諾状態等も保存されないことになる。

しかしもともとこのタイミングでしか保存していないのはおそらく race condition になった場合データの不整合が起きるためと考えられるので、母港に戻った瞬間や任務の受諾時等、複数のAPIが短い間に呼ばれるようなタイミングで保存を行うと結局不整合が起きてしまい好ましくないと思われる。そこで複数のAPIの呼び出しタイミングを調べてみると、戦闘終了時に呼ばれる battleresult API であれば前後に他のAPIが呼ばれることがないのでこのタイミングでデータを保存することとした。

#### 関連するIssue
#18 

