### PR TITLE
半日の戦果を表示する

### DIFF
--- a/src/main/java/logbook/api/ApiGetMemberBasic.java
+++ b/src/main/java/logbook/api/ApiGetMemberBasic.java
@@ -2,6 +2,7 @@ package logbook.api;
 
 import javax.json.JsonObject;
 
+import logbook.bean.AppExpRecords;
 import logbook.bean.Basic;
 import logbook.proxy.RequestMetaData;
 import logbook.proxy.ResponseMetaData;
@@ -18,6 +19,7 @@ public class ApiGetMemberBasic implements APIListenerSpi {
         JsonObject data = json.getJsonObject("api_data");
         if (data != null) {
             Basic.updateBasic(Basic.get(), data);
+            AppExpRecords.get().update(Basic.get());
         }
     }
 

--- a/src/main/java/logbook/api/ApiGetMemberRequireInfo.java
+++ b/src/main/java/logbook/api/ApiGetMemberRequireInfo.java
@@ -36,6 +36,8 @@ public class ApiGetMemberRequireInfo implements APIListenerSpi {
      */
     private void apiBasic(JsonObject object) {
         Basic.updateBasic(Basic.get(), object);
+        // require_info の時の api_basic は戦果が送られてこないので更新すべきでない
+        //AppExpRecords.get().update(Basic.get());
     }
 
     /**

--- a/src/main/java/logbook/api/ApiPortPort.java
+++ b/src/main/java/logbook/api/ApiPortPort.java
@@ -18,6 +18,7 @@ import javafx.application.Platform;
 import logbook.bean.AppBouyomiConfig;
 import logbook.bean.AppCondition;
 import logbook.bean.AppConfig;
+import logbook.bean.AppExpRecords;
 import logbook.bean.Basic;
 import logbook.bean.DeckPort;
 import logbook.bean.DeckPortCollection;
@@ -68,6 +69,7 @@ public class ApiPortPort implements APIListenerSpi {
      */
     private void apiBasic(JsonObject object) {
         Basic.updateBasic(Basic.get(), object);
+        AppExpRecords.get().update(Basic.get());
     }
 
     /**

--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -57,6 +57,18 @@ public final class AppConfig implements Serializable {
     /** 遠征完了時のリマインド(秒) */
     private int remind = 60;
 
+    /** 戦果ペインの表示 */
+    private boolean showAchievement = false;
+
+    /** 遠征ペインの表示 */
+    private boolean showMission = true;
+
+    /** 入渠ペインの表示 */
+    private boolean showNdock = true;
+
+    /** 任務ペインの表示 */
+    private boolean showQuest = true;
+
     /** 艦娘の画像に経験値バーを表示する */
     private boolean visibleExpGauge = true;
 

--- a/src/main/java/logbook/bean/AppExpRecords.java
+++ b/src/main/java/logbook/bean/AppExpRecords.java
@@ -1,0 +1,73 @@
+package logbook.bean;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import logbook.internal.Config;
+import lombok.Data;
+
+/**
+ * 戦果のベースとなる提督経験値の記録
+ */
+@Data
+public class AppExpRecords {
+    /** この半日の基準戦果 (2時/14時を過ぎて最初の経験値） */
+    private Long exp12h;
+    /** exp12h を設定した時刻 [ms] */
+    private long time12h;
+    /** この1日の基準戦果 */
+    private Long exp1d;
+    /** exp1d を設定した時刻 [ms] */
+    private long time1d;
+
+    public void update(Basic basic) {
+        // 戦果は JST 2時/14時で切り替わるため UTC+7 を基準とすると計算しやすい
+        final ZoneId UTC7 = ZoneId.of("UTC+07:00");
+        ZonedDateTime now = ZonedDateTime.now(UTC7);
+        long base = getBase(now);
+        long base12 = getBase(Instant.ofEpochMilli(this.time12h).atZone(UTC7));
+        long exp = Optional.ofNullable(Basic.get()).map(Basic::getExperience).map(Integer::longValue).orElse(0L);
+        if (base != base12) {
+            if (getBase(now.minusHours(12)) == base12) {
+                // 1日用の経験値にシフト
+                this.exp1d = this.exp12h;
+                this.time1d = this.time12h;
+            } else {
+                // もっと前になってしまったので今の値を埋める
+                this.exp1d = exp;
+                this.time1d = now.toInstant().toEpochMilli();
+            }
+            this.exp12h = exp;
+            this.time12h = now.toInstant().toEpochMilli();
+        }
+    }
+
+
+    private static long getBase(ZonedDateTime time) {
+        ZonedDateTime base = time.truncatedTo(ChronoUnit.HOURS);
+        if (base.getHour() < 12) {
+            // AM
+            base = base.withHour(0);
+        } else {
+            // PM
+            base = base.withHour(12);
+        }
+        return base.toEpochSecond();
+    }
+
+    /**
+     * アプリケーションのデフォルト設定ディレクトリから{@link AppExpRecords}を取得します、
+     * これは次の記述と同等です
+     * <blockquote>
+     *     <code>Config.getDefault().get(AppExpRecords.class, AppExpRecords::new)</code>
+     * </blockquote>
+     *
+     * @return {@link AppExpRecords}
+     */
+    public static AppExpRecords get() {
+        return Config.getDefault().get(AppExpRecords.class, AppExpRecords::new);
+    }
+}

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -124,6 +124,22 @@ public class ConfigController extends WindowController {
     @FXML
     private ChoiceBox<Pair<String, String>> toastLocation;
 
+    /** 戦果ペインの表示 */
+    @FXML
+    private CheckBox showAchievement;
+
+    /** 遠征ペインの表示 */
+    @FXML
+    private CheckBox showMission;
+
+    /** 入渠ペインの表示 */
+    @FXML
+    private CheckBox showNdock;
+
+    /** 任務ペインの表示 */
+    @FXML
+    private CheckBox showQuest;
+    
     /** 遠征完了時のリマインド */
     @FXML
     private CheckBox useRemind;
@@ -389,6 +405,10 @@ public class ConfigController extends WindowController {
         this.defaultNotifySound.setText(conf.getDefaultNotifySound());
         this.useToast.setSelected(conf.isUseToast());
         this.toastLocation.setValue(this.toastLocation.getItems().stream().filter(value -> value.getValue().equals(conf.getToastLocation())).findAny().orElse(this.toastLocation.getItems().get(3)));
+        this.showAchievement.setSelected(conf.isShowAchievement());
+        this.showMission.setSelected(conf.isShowMission());
+        this.showNdock.setSelected(conf.isShowNdock());
+        this.showQuest.setSelected(conf.isShowQuest());
         this.useRemind.setSelected(conf.isUseRemind());
         this.remind.setText(Integer.toString(conf.getRemind()));
         this.soundLevel.setText(Integer.toString(conf.getSoundLevel()));
@@ -513,6 +533,10 @@ public class ConfigController extends WindowController {
         conf.setDefaultNotifySound(this.defaultNotifySound.getText());
         conf.setUseToast(this.useToast.isSelected());
         conf.setToastLocation(this.toastLocation.getValue().getValue());
+        conf.setShowAchievement(this.showAchievement.isSelected());
+        conf.setShowMission(this.showMission.isSelected());
+        conf.setShowNdock(this.showNdock.isSelected());
+        conf.setShowQuest(this.showQuest.isSelected());
         conf.setUseRemind(this.useRemind.isSelected());
         conf.setRemind(Math.max(this.toInt(this.remind.getText()), 10));
         conf.setSoundLevel(this.toInt(this.soundLevel.getText()));

--- a/src/main/java/logbook/internal/gui/MainController.java
+++ b/src/main/java/logbook/internal/gui/MainController.java
@@ -2,8 +2,13 @@ package logbook.internal.gui;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -18,6 +23,7 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
+import javafx.scene.control.Label;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.image.ImageView;
@@ -27,6 +33,7 @@ import logbook.Messages;
 import logbook.bean.AppBouyomiConfig;
 import logbook.bean.AppCondition;
 import logbook.bean.AppConfig;
+import logbook.bean.AppExpRecords;
 import logbook.bean.AppQuest;
 import logbook.bean.AppQuestCollection;
 import logbook.bean.Basic;
@@ -92,6 +99,18 @@ public class MainController extends WindowController {
 
     @FXML
     private TabPane fleetTab;
+
+    @FXML
+    private Label achievementLabel1;
+
+    @FXML
+    private Label achievementValue1;
+
+    @FXML
+    private Label achievementLabel2;
+
+    @FXML
+    private Label achievementValue2;
 
     @FXML
     private VBox missionbox;
@@ -190,6 +209,8 @@ public class MainController extends WindowController {
         try {
             // 所有装備/所有艦娘
             this.button();
+            // 戦果
+            this.achievement();
             // 艦隊タブ・遠征
             this.checkPort();
             // 泊地修理タイマー
@@ -247,6 +268,33 @@ public class MainController extends WindowController {
             }
         } else {
             this.ship.getStyleClass().remove(FULLY_CLASS);
+        }
+    }
+
+    /**
+     * 戦果の計算
+     */
+    private void achievement() {
+        final ZoneId JST = ZoneId.of("UTC+07:00");
+        final DecimalFormat format = new DecimalFormat("0.000");
+        final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("d日a");
+        AppExpRecords records = AppExpRecords.get();
+        long exp = Optional.ofNullable(Basic.get()).map(Basic::getExperience).map(Integer::longValue).orElse(0L);
+        if (records.getExp12h() != null) {
+            ZonedDateTime start = Instant.ofEpochMilli(records.getTime12h()).atZone(JST);
+            this.achievementLabel2.setText(start.format(dateFormatter) + "(" + (start.getHour()+2) + "- )");
+            this.achievementValue2.setText(format.format((exp - records.getExp12h())*7f/10000));
+        } else {
+            this.achievementLabel2.setText("");
+            this.achievementValue2.setText("");
+        }
+        if (records.getExp1d() != null && records.getTime1d() != records.getTime12h()) {
+            ZonedDateTime start = Instant.ofEpochMilli(records.getTime1d()).atZone(JST);
+            this.achievementLabel1.setText(start.format(dateFormatter) + "(" + (start.getHour()+2) + "-" + (start.getHour()/12*12+14)+")");
+            this.achievementValue1.setText(format.format((records.getExp12h()-records.getExp1d())*7f/10000));
+        } else {
+            this.achievementLabel1.setText("");
+            this.achievementValue1.setText("");
         }
     }
 

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -108,6 +108,13 @@
                               <Label text="報告書の保存先" GridPane.rowIndex="16" />
                               <TextField fx:id="reportDir" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="16" />
                               <Button mnemonicParsing="false" onAction="#selectReportDir" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="16" />
+                              <Label text="母港タブ表示内容" GridPane.rowIndex="17" />
+                              <HBox  alignment="CENTER_LEFT" GridPane.rowIndex="17" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" spacing="5">
+                              <CheckBox fx:id="showAchievement" mnemonicParsing="false" text="戦果" GridPane.columnIndex="1" GridPane.rowIndex="17"/>
+                              <CheckBox fx:id="showMission" mnemonicParsing="false" text="遠征" GridPane.columnIndex="2" GridPane.rowIndex="17"/>
+                              <CheckBox fx:id="showNdock" mnemonicParsing="false" text="入渠" GridPane.columnIndex="3" GridPane.rowIndex="17"/>
+                              <CheckBox fx:id="showQuest" mnemonicParsing="false" text="任務" GridPane.columnIndex="3" GridPane.rowIndex="17"/>
+                              </HBox>
                            </children>
                         </GridPane>
                      </children>

--- a/src/main/resources/logbook/gui/main.css
+++ b/src/main/resources/logbook/gui/main.css
@@ -71,6 +71,14 @@ TabPane .tab.empty .tab-label {
     -fx-font-size: 1.1em;
     -fx-font-weight: bold;
 }
+.achievement .name {
+    -fx-font-size: 10pt;
+}
+.achievement .achievement {
+    -fx-font-size: 14pt;
+    -fx-font-weight: bold;
+}
+
 .mission .progress {
     -fx-background-color: transparent;
     -fx-background-radius: 0;

--- a/src/main/resources/logbook/gui/main.fxml
+++ b/src/main/resources/logbook/gui/main.fxml
@@ -2,10 +2,12 @@
 
 <?import java.net.URL?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
@@ -26,6 +28,26 @@
                      <content>
                         <VBox fx:id="infobox">
                            <children>
+                              <TitledPane fx:id="achievementPane" animated="false" text="戦果">
+                                 <content>
+                                    <HBox style="-fx-padding:0;" spacing="10">
+                                       <children>
+                                          <AnchorPane HBox.hgrow="always" styleClass="achievement" prefHeight="40.0" minWidth="130.0">
+                                             <children>
+                                                <Label fx:id="achievementLabel1" maxWidth="130.0" prefWidth="130.0" styleClass="name" AnchorPane.leftAnchor="1.0" AnchorPane.topAnchor="1.0" text=""/>
+                                                <Label fx:id="achievementValue1" styleClass="achievement" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="1.0" text=""/>
+                                             </children>
+                                          </AnchorPane>
+                                          <AnchorPane HBox.hgrow="always" styleClass="achievement" prefHeight="40.0" minWidth="130.0">
+                                             <children>
+                                                <Label fx:id="achievementLabel2" maxWidth="130.0" prefWidth="130.0" styleClass="name" AnchorPane.leftAnchor="1.0" AnchorPane.topAnchor="1.0" text=""/>
+                                                <Label fx:id="achievementValue2" styleClass="achievement" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="1.0" text=""/>
+                                             </children>
+                                          </AnchorPane>
+                                       </children>
+                                    </HBox>
+                                 </content>
+                              </TitledPane>
                               <TitledPane animated="false" text="遠征">
                                  <content>
                                     <VBox fx:id="missionbox" />

--- a/src/main/resources/logbook/gui/main.fxml
+++ b/src/main/resources/logbook/gui/main.fxml
@@ -48,12 +48,12 @@
                                     </HBox>
                                  </content>
                               </TitledPane>
-                              <TitledPane animated="false" text="遠征">
+                              <TitledPane fx:id="missionPane" animated="false" text="遠征">
                                  <content>
                                     <VBox fx:id="missionbox" />
                                  </content>
                               </TitledPane>
-                              <TitledPane animated="false" text="入渠">
+                              <TitledPane fx:id="ndockPane" animated="false" text="入渠">
                                  <content>
                                     <VBox>
                                        <children>
@@ -63,7 +63,7 @@
                                     </VBox>
                                  </content>
                               </TitledPane>
-                              <TitledPane animated="false" text="任務">
+                              <TitledPane fx:id="questPane" animated="false" text="任務">
                                  <content>
                                     <VBox fx:id="questbox" />
                                  </content>

--- a/src/main/resources/logbook/gui/main_wide.fxml
+++ b/src/main/resources/logbook/gui/main_wide.fxml
@@ -2,11 +2,13 @@
 
 <?import java.net.URL?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.input.KeyCodeCombination?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
@@ -30,6 +32,26 @@
                      <content>
                         <VBox fx:id="infobox">
                            <children>
+                              <TitledPane fx:id="achievementPane" animated="false" text="戦果">
+                                 <content>
+                                    <HBox style="-fx-padding:0;" spacing="10">
+                                       <children>
+                                          <AnchorPane HBox.hgrow="always" styleClass="achievement" prefHeight="40.0" minWidth="130.0">
+                                             <children>
+                                                <Label fx:id="achievementLabel1" maxWidth="130.0" prefWidth="130.0" styleClass="name" AnchorPane.leftAnchor="1.0" AnchorPane.topAnchor="1.0" text=""/>
+                                                <Label fx:id="achievementValue1" styleClass="achievement" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="1.0" text=""/>
+                                             </children>
+                                          </AnchorPane>
+                                          <AnchorPane HBox.hgrow="always" styleClass="achievement" prefHeight="40.0" minWidth="130.0">
+                                             <children>
+                                                <Label fx:id="achievementLabel2" maxWidth="130.0" prefWidth="130.0" styleClass="name" AnchorPane.leftAnchor="1.0" AnchorPane.topAnchor="1.0" text=""/>
+                                                <Label fx:id="achievementValue2" styleClass="achievement" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="1.0" text=""/>
+                                             </children>
+                                          </AnchorPane>
+                                       </children>
+                                    </HBox>
+                                 </content>
+                              </TitledPane>
                               <TitledPane animated="false" text="遠征">
                                  <content>
                                     <VBox fx:id="missionbox" />

--- a/src/main/resources/logbook/gui/main_wide.fxml
+++ b/src/main/resources/logbook/gui/main_wide.fxml
@@ -52,12 +52,12 @@
                                     </HBox>
                                  </content>
                               </TitledPane>
-                              <TitledPane animated="false" text="遠征">
+                              <TitledPane fx:id="missionPane" animated="false" text="遠征">
                                  <content>
                                     <VBox fx:id="missionbox" />
                                  </content>
                               </TitledPane>
-                              <TitledPane animated="false" text="入渠">
+                              <TitledPane fx:id="ndockPane" animated="false" text="入渠">
                                  <content>
                                     <VBox>
                                        <children>
@@ -67,7 +67,7 @@
                                     </VBox>
                                  </content>
                               </TitledPane>
-                              <TitledPane animated="false" text="任務">
+                              <TitledPane fx:id="questPane" animated="false" text="任務">
                                  <content>
                                     <VBox fx:id="questbox" />
                                  </content>


### PR DESCRIPTION
#### 変更内容
半日分の戦果を表示する。方法としては提督経験値を取得した時（母港に戻るなど）、対象戦果計算時間幅（2-14時または14-26時）が変化したかどうかを確認し、もし変化した場合その提督経験値をその時間幅における基準経験値として保存する。そしてその基準経験値を利用して現在の提督経験値との差からその時間幅での戦果を計算して表示する。表示は最新の半日（2-14時または14-26時）の戦果とその前の半日の戦果を表示する。

![image](https://user-images.githubusercontent.com/3181895/102849391-65c3ac80-445a-11eb-9c2c-d77562fff48f.png)

また、戦果は必ずしも全ての提督にとって有用な情報とは限らないので、設定から表示するかどうかを設定可能とした（デフォルトはオフ）。同様の機構により他のペイン（遠征、入渠、任務）も表示・非表示を設定可能とした（デフォルトはオン）。

![image](https://user-images.githubusercontent.com/3181895/102849563-c18e3580-445a-11eb-9482-6d4844eeaa6e.png)

#### 関連するIssue
#14

