### PR TITLE
TPを艦隊タブに表示 Sdk0815#22

### DIFF
--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -883,6 +883,10 @@ public class Ships {
         
         // 艦娘TP
         int value = shipMst(ship).map(ShipType::toShipType).map(SHIP_TYPE_TP_MAP::get).orElse(0);
+        if (ship.getShipId() == 487) {
+            // 鬼怒改二は大発動艇を1つ内蔵
+            value += 8;
+        }
         // 装備TP
         value += Stream.concat(ship.getSlot().stream(), Stream.of(ship.getSlotEx()))
                 .map(itemMap::get)

--- a/src/main/java/logbook/internal/gui/FleetTabPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabPane.java
@@ -153,6 +153,14 @@ public class FleetTabPane extends ScrollPane {
     @FXML
     private Label sakutekisum;
 
+    /** TP合計アイコン */
+    @FXML
+    private ImageView tpsumImg;
+
+    /** TP合計 */
+    @FXML
+    private Label tpsum;
+
     /** 注釈 */
     @FXML
     private VBox remark;
@@ -309,6 +317,9 @@ public class FleetTabPane extends ScrollPane {
         this.taissum.setText(Integer.toString(withoutEscape.stream().mapToInt(ship -> ship.getTaisen().get(0)).sum()));
         // 索敵合計
         this.sakutekisum.setText(Integer.toString(withoutEscape.stream().mapToInt(ship -> ship.getSakuteki().get(0)).sum()));
+        // TP合計
+        int tp = withoutEscape.stream().mapToInt(Ships::transportPoint).sum();
+        this.tpsum.setText(tp + "/" + (int)(tp*7/10));
 
         ObservableList<Node> childs = this.ships.getChildren();
         childs.clear();
@@ -417,6 +428,7 @@ public class FleetTabPane extends ScrollPane {
         this.taikusumImg.setImage(Items.itemImageByType(15));
         this.taissumImg.setImage(Items.itemImageByType(17));
         this.sakutekisumImg.setImage(Items.itemImageByType(11));
+        this.tpsumImg.setImage(Items.itemImageByType(25));
     }
 
     /**

--- a/src/main/java/logbook/internal/gui/FleetTabPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabPane.java
@@ -161,6 +161,14 @@ public class FleetTabPane extends ScrollPane {
     @FXML
     private Label tpsum;
 
+    /** 艦隊速度アイコン */
+    @FXML
+    private ImageView speedImg;
+
+    /** 艦隊速度 */
+    @FXML
+    private Label speed;
+    
     /** 注釈 */
     @FXML
     private VBox remark;
@@ -321,6 +329,25 @@ public class FleetTabPane extends ScrollPane {
         int tp = withoutEscape.stream().mapToInt(Ships::transportPoint).sum();
         this.tpsum.setText(tp + "/" + (int)(tp*7/10));
 
+        // 艦隊速度 - 各艦の速度のうち最低の速度を艦隊の速度とする
+        String label;
+        int speed = this.shipList.stream().map(Ship::getSoku).mapToInt(Integer::intValue).min().orElse(0);
+        this.speed.setStyle("");
+        if (speed >= 20) {
+            label = "最速";
+            this.speed.setStyle("-fx-text-fill: #9FEEEE;");
+        } else if (speed >= 15) {
+            label = "高速+";
+            this.speed.setStyle("-fx-text-fill: #CFEEEE;");
+        } else if (speed >= 10) {
+            label = "高速";
+        } else if (speed >= 5) {
+            label = "低速";
+        } else {
+            label = "(不明)";
+        }
+        this.speed.setText(label);
+
         ObservableList<Node> childs = this.ships.getChildren();
         childs.clear();
         this.shipList.stream()
@@ -429,6 +456,7 @@ public class FleetTabPane extends ScrollPane {
         this.taissumImg.setImage(Items.itemImageByType(17));
         this.sakutekisumImg.setImage(Items.itemImageByType(11));
         this.tpsumImg.setImage(Items.itemImageByType(25));
+        this.speedImg.setImage(Items.itemImageByType(19));
     }
 
     /**

--- a/src/main/resources/logbook/gui/fleet_tab.css
+++ b/src/main/resources/logbook/gui/fleet_tab.css
@@ -9,3 +9,8 @@
 :enablebgimage.image .label,:enablebgimage.image .hyperlink {
     -fx-effect: dropshadow(gaussian, white, 3, 0.8, 0, 0);
 }
+
+#speed {
+    -fx-effect: dropshadow(gaussian, black, 2, 1, 0, 0);
+    -fx-text-fill: white;
+}

--- a/src/main/resources/logbook/gui/fleet_tab.fxml
+++ b/src/main/resources/logbook/gui/fleet_tab.fxml
@@ -114,6 +114,13 @@
                                  </children>
                               </HBox>
                               <Label fx:id="tpsum" styleClass="value" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                              <HBox GridPane.columnIndex="2" GridPane.rowIndex="5">
+                                 <children>
+                                    <ImageView fx:id="speedImg" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true" />
+                                    <Label prefHeight="24.0" text="艦隊速度:"/>
+                                 </children>
+                              </HBox>
+                              <Label fx:id="speed" styleClass="value" GridPane.columnIndex="3" GridPane.rowIndex="5" />
                            </children>
                         </GridPane>
                      </children>

--- a/src/main/resources/logbook/gui/fleet_tab.fxml
+++ b/src/main/resources/logbook/gui/fleet_tab.fxml
@@ -65,7 +65,7 @@
                               <HBox alignment="CENTER_LEFT" GridPane.rowIndex="2">
                                  <children>
                                     <ImageView fx:id="lvsumImg" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true" />
-                                    <Label text="艦娘レベル合計:" />
+                                    <Label text="艦娘Lv合計:" />
                                  </children>
                               </HBox>
                               <Label fx:id="lvsum" styleClass="value" GridPane.columnIndex="1" GridPane.rowIndex="2" />
@@ -107,6 +107,13 @@
                                  </children>
                               </HBox>
                               <Label fx:id="sakutekisum" styleClass="value" GridPane.columnIndex="3" GridPane.rowIndex="4" />
+                              <HBox alignment="CENTER_LEFT" GridPane.columnIndex="0" GridPane.rowIndex="5">
+                                 <children>
+                                    <ImageView fx:id="tpsumImg" fitHeight="24.0" fitWidth="24.0" pickOnBounds="true" preserveRatio="true" />
+                                    <Label text="TP(S/A):" />
+                                 </children>
+                              </HBox>
+                              <Label fx:id="tpsum" styleClass="value" GridPane.columnIndex="1" GridPane.rowIndex="5" />
                            </children>
                         </GridPane>
                      </children>


### PR DESCRIPTION
#### 変更内容
TP(輸送量)を艦隊タブに表示する。計算方法は[こちら](https://wikiwiki.jp/kancolle/%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E6%B5%B7%E5%9F%9F%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88/%E8%BC%B8%E9%80%81%E8%B3%87%E6%BA%90%E9%87%8F%E3%81%AE%E8%A8%88%E7%AE%97_2019%E7%A7%8B)を参考にした。Issueには連合艦隊で合計してほしい旨の要望もあったが、ほかの値（制空値や判定式など）も合計されていない現状を鑑みて、まずは艦隊ごとの表示としている。またTPの表示が必要になる場面は限られているものの、ほかの値（火力合計等）も不要な場面も多いのに常時表示していることから、こちらも常時表示するようにして設定等のサポートは行わないようにした。

![image](https://user-images.githubusercontent.com/3181895/102849978-a96ae600-445b-11eb-982b-1ad797e83f02.png)

また、艦隊の速度も表示しておくと何かと役に立つ時があるので表示するようにした。

![image](https://user-images.githubusercontent.com/3181895/102856645-387efa80-446a-11eb-8c7f-1c9369ac213a.png)

#### 関連するIssue
#22

