### PR TITLE
補給状況をポップアップに表示 Sdk0815#23

### DIFF
--- a/src/main/java/logbook/internal/gui/FleetTabShipPopup.java
+++ b/src/main/java/logbook/internal/gui/FleetTabShipPopup.java
@@ -25,6 +25,21 @@ import logbook.internal.Ships;
  */
 public class FleetTabShipPopup extends VBox {
 
+    @FXML
+    private Label fuel;
+    @FXML
+    private Label fuelDesc;
+    @FXML
+    private Label bull;
+    @FXML
+    private Label bullDesc;
+    @FXML
+    private HBox planeBox;
+    @FXML
+    private Label plane;
+    @FXML
+    private Label planeDesc;
+
     private Chara chara;
 
     /**
@@ -48,7 +63,30 @@ public class FleetTabShipPopup extends VBox {
     void initialize() {
         if (this.chara.isShip()) {
             Ship ship = this.chara.asShip();
-
+            Ships.shipMst(this.chara).map(ShipMst::getFuelMax).ifPresent(max -> {
+                this.fuel.setText(ship.getFuel()*100/max+"%");
+                this.fuelDesc.setText("("+ship.getFuel()+"/"+max+")");
+            });
+            Ships.shipMst(this.chara).map(ShipMst::getBullMax).ifPresent(max -> {
+                this.bull.setText(ship.getBull()*100/max+"%");
+                this.bullDesc.setText("("+ship.getBull()+"/"+max+")");
+            });
+            int maxPlane = Ships.shipMst(this.chara)
+                    .map(ShipMst::getMaxeq)
+                    .map(eq -> eq.stream().filter(e -> e > 0).mapToInt(Integer::intValue).sum())
+                    .orElse(0);
+            if (maxPlane == 0) {
+                this.planeBox.setVisible(false);
+                this.planeBox.setManaged(false);
+            } else {
+                int total = ship.getOnslot().stream().filter(e -> e > 0).mapToInt(Integer::intValue).sum();
+                if (total >= maxPlane) {
+                    this.plane.setText("なし");
+                } else {
+                    this.plane.setText((maxPlane-total) + "機");
+                    this.planeDesc.setText("(要ボーキ"+(maxPlane-total)*5 + ")");
+                }
+            }
             for (int i = 0; i < ship.getSlotnum(); i++) {
                 this.getChildren().add(new FleetTabShipPopupItem(this.chara, i));
             }

--- a/src/main/resources/logbook/gui/fleet_tab_popup.css
+++ b/src/main/resources/logbook/gui/fleet_tab_popup.css
@@ -1,0 +1,16 @@
+.popup-item {
+    -fx-alignment: CENTER;
+}
+.item-title {
+    -fx-min-width: 6em;
+    -fx-padding: 0 0.5em 0 0;
+    -fx-alignment: CENTER_RIGHT;
+}
+.item-percent {
+    -fx-min-width: 4em;
+    -fx-padding: 0 0.5em 0 0;
+    -fx-alignment: CENTER_RIGHT;
+}
+.item-desc {
+    -fx-min-width: 8em;
+}

--- a/src/main/resources/logbook/gui/fleet_tab_popup.fxml
+++ b/src/main/resources/logbook/gui/fleet_tab_popup.fxml
@@ -2,9 +2,28 @@
 
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.HBox?>
 
-<fx:root fillWidth="false" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="150.0" stylesheets="@popup.css" type="VBox" xmlns="http://javafx.com/javafx/8.0.131" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root fillWidth="false" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="150.0" stylesheets="@popup.css,@fleet_tab_popup.css" type="VBox" xmlns="http://javafx.com/javafx/8.0.131" xmlns:fx="http://javafx.com/fxml/1">
    <children>
+      <Label styleClass="title" text="補給状況" />
+      <VBox>
+         <HBox styleClass="popup-item">
+            <Label styleClass="item-title" text="燃料" />
+            <Label fx:id="fuel" styleClass="item-percent" text="(不明)" />
+            <Label fx:id="fuelDesc" styleClass="item-desc" text="" />
+         </HBox>
+         <HBox>
+            <Label styleClass="item-title" text="弾薬" />
+            <Label fx:id="bull" styleClass="item-percent" text="(不明)" />
+            <Label fx:id="bullDesc" styleClass="item-desc" text="" />
+         </HBox>
+         <HBox fx:id="planeBox">
+            <Label styleClass="item-title" text="艦載機損耗" />
+            <Label fx:id="plane" styleClass="item-percent" text="(不明)" />
+            <Label fx:id="planeDesc" styleClass="item-desc" text="" />
+         </HBox>
+      </VBox>
       <Label styleClass="title" text="装備" />
    </children>
 </fx:root>


### PR DESCRIPTION
#### 変更内容
艦娘の装備等を表示しているポップアップに燃料、弾薬、艦載機の損耗状況を表示するようにした。

![image](https://user-images.githubusercontent.com/3181895/103553392-b9b9a100-4ef0-11eb-9480-6dd77380ab7d.png)

艦載機を搭載できない艦の場合は艦載機の損耗状況は非表示となる。

![image](https://user-images.githubusercontent.com/3181895/103553470-d524ac00-4ef0-11eb-9848-fc325c3d75db.png)

#### 関連するIssue
#23

