### PR TITLE
節分Weekly任務を追加

### DIFF
--- a/src/main/resources/logbook/quest/840.json
+++ b/src/main/resources/logbook/quest/840.json
@@ -1,0 +1,19 @@
+{
+    "type": "出撃",
+    "resetType" : "ウィークリー",
+    "filter" : {
+        "area": ["2-1", "2-2", "2-3"],
+        "fleet": {
+            "operator": "AND",
+            "conditions": [
+                {"stype": ["軽巡洋艦", "重雷装巡洋艦", "練習巡洋艦", "軽空母"], "order": 1},
+                {"stype": ["駆逐艦", "海防艦"], "count": 3, "operator": "GE"}
+            ]
+        }
+    },
+    "conditions" : [
+        {"boss": true, "area": ["2-1"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["2-2"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["2-3"], "rank": ["S", "A"], "count": 1}
+    ]
+}

--- a/src/main/resources/logbook/quest/841.json
+++ b/src/main/resources/logbook/quest/841.json
@@ -1,0 +1,38 @@
+{
+    "type": "出撃",
+    "resetType" : "ウィークリー",
+    "filter" : {
+        "area": ["4-1", "4-2", "4-3"],
+        "fleet": {
+            "operator": "OR",
+            "conditions": [
+                {
+                    "operator": "AND",
+                        "conditions": [
+                            {"stype": ["水上機母艦"], "order": 1},
+                            {"stype": ["水上機母艦"], "count": 1, "operator": "GE"}
+                        ]
+                },
+                {
+                    "operator": "AND",
+                        "conditions": [
+                            {"stype": ["航空巡洋艦"], "order": 1},
+                            {"stype": ["航空巡洋艦"], "count": 1, "operator": "GE"}
+                        ]
+                },
+                {
+                    "operator": "AND",
+                        "conditions": [
+                            {"stype": ["重巡洋艦"], "order": 1},
+                            {"stype": ["重巡洋艦"], "count": 1, "operator": "GE"}
+                        ]
+                }
+            ]
+        }
+    },
+    "conditions" : [
+        {"boss": true, "area": ["4-1"], "rank": ["S"], "count": 1},
+        {"boss": true, "area": ["4-2"], "rank": ["S"], "count": 1},
+        {"boss": true, "area": ["4-3"], "rank": ["S"], "count": 1}
+    ]
+}

--- a/src/main/resources/logbook/quest/843.json
+++ b/src/main/resources/logbook/quest/843.json
@@ -1,0 +1,19 @@
+{
+    "type": "出撃",
+    "resetType" : "ウィークリー",
+    "filter" : {
+        "area": ["5-2", "5-5", "6-4"],
+        "fleet": {
+            "operator": "AND",
+            "conditions": [
+                {"stype": ["戦艦", "正規空母", "装甲空母", "軽空母"], "order": 1},
+                {"stype": ["駆逐艦"], "count": 2, "operator": "GE"}
+            ]
+        }
+    },
+    "conditions" : [
+        {"boss": true, "area": ["5-2"], "rank": ["S"], "count": 1},
+        {"boss": true, "area": ["5-5"], "rank": ["S"], "count": 1},
+        {"boss": true, "area": ["6-4"], "rank": ["S"], "count": 1}
+    ]
+}


### PR DESCRIPTION
#### 変更内容
節分任務のうちWeeklyの出撃任務のカウントを実装する。昨年の節分任務と同じIDが使われているので、（来年も同じIDが使い回される恐れがありそうなると間違ったカウントを行ってしまうので）任務が終わり次第削除する予定。

#### 関連するIssue
N/A

