### PR TITLE
海域札なしタブ及びラベルなしフィルターの実装 Sdk0815#40

### DIFF
--- a/src/main/java/logbook/internal/ShipFilter.java
+++ b/src/main/java/logbook/internal/ShipFilter.java
@@ -72,14 +72,19 @@ public interface ShipFilter extends Predicate<ShipItem> {
 
     @Builder
     public static class LabelFilter implements ShipFilter {
+        public static String NO_LABEL = "";
 
         /** ラベル */
         private String labelValue;
 
         @Override
         public boolean test(ShipItem ship) {
-            if (ship == null)
+            if (ship == null || this.labelValue == null) {
                 return false;
+            }
+            if (NO_LABEL.equals(this.labelValue)) {
+                return ship.getLabel().isEmpty();
+            }
             return ship.getLabel().contains(this.labelValue);
         }
     }

--- a/src/main/java/logbook/internal/gui/ShipController.java
+++ b/src/main/java/logbook/internal/gui/ShipController.java
@@ -144,6 +144,22 @@ public class ShipController extends WindowController {
      */
     private void addLabelTabs() {
         Map<Integer, Set<String>> labelMap = ShipLabelCollection.get().getLabels();
+        // 海域札(手動のラベルは除く)がついている艦がいる場合のみ表示
+        if (ShipCollection.get().getShipMap().values().stream()
+            .map(Ship::getSallyArea)
+            .map(SeaArea::fromArea)
+            .filter(Objects::nonNull)
+            .count() > 0) {
+            // 「海域札なし」タブには手動でラベルを付けただけの艦を表示するため SallyArea のみチェック
+            ShipTablePane noLabelPane = new ShipTablePane(() -> {
+                return ShipCollection.get().getShipMap().values().stream()
+                    .filter(ship -> SeaArea.fromArea(ship.getSallyArea()) == null)
+                    .sorted(Comparator.comparing(Ship::getLv).reversed()
+                            .thenComparing(Comparator.comparing(Ship::getShipId)))
+                    .collect(Collectors.toList());
+            }, "海域札なし");
+            this.tab.getTabs().add(new Tab("海域札なし", noLabelPane));
+        }
         ShipCollection.get().getShipMap().values().stream()
                 .flatMap(ship -> {
                     List<String> label = new ArrayList<>();

--- a/src/main/java/logbook/internal/gui/ShipTablePane.java
+++ b/src/main/java/logbook/internal/gui/ShipTablePane.java
@@ -55,6 +55,7 @@ import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import javafx.util.StringConverter;
 import logbook.bean.AppConfig;
 import logbook.bean.AppShipTableConfig;
 import logbook.bean.AppShipTableConfig.AppShipTableTabConfig;
@@ -434,6 +435,17 @@ public class ShipTablePane extends VBox {
             this.labelFilter.selectedProperty().addListener((ob, ov, nv) -> {
                 this.labelValue.setDisable(!nv);
             });
+            this.labelValue.setConverter(new StringConverter<String>() {
+                @Override
+                public String toString(String object) {
+                    return object.equals(ShipFilter.LabelFilter.NO_LABEL) ? "(ラベルなし)" : object;
+                }
+                
+                @Override
+                public String fromString(String string) {
+                    return string;
+                }
+            });
             this.slotExFilter.selectedProperty().addListener((ob, ov, nv) -> {
                 this.slotExValue.setDisable(!nv);
             });
@@ -573,6 +585,7 @@ public class ShipTablePane extends VBox {
      */
     private void updateLabel() {
         Set<String> labels = new TreeSet<>();
+        labels.add(ShipFilter.LabelFilter.NO_LABEL);
         this.shipItems.forEach(ship -> {
             labels.addAll(ship.getLabel());
         });
@@ -667,6 +680,7 @@ public class ShipTablePane extends VBox {
                     labels.add(label);
                 }
                 this.updateLabel();
+                this.updateFilter();
                 this.table.refresh();
             }
         }
@@ -722,6 +736,7 @@ public class ShipTablePane extends VBox {
                     });
                 }
                 this.updateLabel();
+                this.updateFilter();
                 this.table.refresh();
             }
         }
@@ -876,7 +891,7 @@ public class ShipTablePane extends VBox {
         }
         if (this.labelFilter.isSelected()) {
             filter = this.filterAnd(filter, ShipFilter.LabelFilter.builder()
-                    .labelValue(this.labelValue.getValue() == null ? "" : this.labelValue.getValue())
+                    .labelValue(this.labelValue.getValue())
                     .build());
         }
         if (this.slotExFilter.isSelected()) {


### PR DESCRIPTION
#### 変更内容
海域札なしタブ及びラベルなしフィルターを実装した。

<img width="1094" alt="スクリーンショット 2021-05-20 23 27 35" src="https://user-images.githubusercontent.com/3181895/118996660-0646da00-b9c3-11eb-8599-cf0f719c8394.png">

挙動は
- 「海域札なし」は文字通り海域札がついてない艦娘のみを表示するタブ。手動で付与したラベルが付いている艦を含む。
- 「ラベルなし」フィルターは海域札や手動のラベルが付いてない艦を表示するフィルター。

#### 関連するIssue
#40


