### PR TITLE
7番艦が対空CIすると現在の戦闘や戦闘ログが表示されないのを修正 #48

### DIFF
--- a/src/main/java/logbook/api/ApiReqCombinedBattleGobackPort.java
+++ b/src/main/java/logbook/api/ApiReqCombinedBattleGobackPort.java
@@ -41,7 +41,7 @@ public class ApiReqCombinedBattleGobackPort implements APIListenerSpi {
                     .map(i -> this.getShipId(log.getDeckMap(), i))
                     .ifPresent(escapeSet::add);
             // 護衛
-            Optional.of(escape.getTowIdx())
+            Optional.ofNullable(escape.getTowIdx())
                     .map(e -> e.get(0))
                     .map(i -> this.getShipId(log.getDeckMap(), i))
                     .ifPresent(escapeSet::add);

--- a/src/main/java/logbook/api/ApiReqMapAnchorageRepair.java
+++ b/src/main/java/logbook/api/ApiReqMapAnchorageRepair.java
@@ -1,0 +1,37 @@
+package logbook.api;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import logbook.bean.Ship;
+import logbook.bean.ShipCollection;
+import logbook.internal.JsonHelper;
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * /kcsapi/api_req_map/anchorage_repair
+ */
+@API("/kcsapi/api_req_map/anchorage_repair")
+public class ApiReqMapAnchorageRepair implements APIListenerSpi {
+
+    @Override
+    public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
+        Optional.ofNullable(json.getJsonObject("api_data"))
+            .map(data -> data.getJsonArray("api_ship_data"))
+            .ifPresent(this::apiShipData);
+    }
+    
+    /**
+     * api_data.api_ship_data
+     *
+     * @param array api_ship_data
+     */
+    private void apiShipData(JsonArray array) {
+        Map<Integer, Ship> map = ShipCollection.get().getShipMap();
+        map.putAll(JsonHelper.toMap(array, Ship::getId, Ship::toShip));
+    }
+}

--- a/src/main/java/logbook/internal/gui/BattleDetail.java
+++ b/src/main/java/logbook/internal/gui/BattleDetail.java
@@ -389,7 +389,8 @@ public class BattleDetail extends WindowController {
                         // インデックスは0始まり
                         int idx = stage2.getAirFire().getIdx();
                         Ship ship;
-                        if (idx < 6) {
+                        // 遊撃部隊は7隻なので < 6 ではない
+                        if (idx < ps.getAfterFriend().size()) {
                             ship = ps.getAfterFriend().get(idx);
                         } else {
                             ship = ps.getAfterFriendCombined().get(idx - 6);

--- a/src/main/java/logbook/internal/gui/FleetTabPane.java
+++ b/src/main/java/logbook/internal/gui/FleetTabPane.java
@@ -268,8 +268,10 @@ public class FleetTabPane extends ScrollPane {
         }
         if (this.condRecoverEpoch != Long.MAX_VALUE && ZonedDateTime.now(ZoneId.systemDefault()).toEpochSecond() > this.condRecoverEpoch) {
             this.condRecoverEpoch = Long.MAX_VALUE;
-            String message = Messages.getString("cond.recover", this.port.getName());
-            Tools.Controls.showNotify(null, "疲労抜け", message);
+            if (!AppCondition.get().isMapStart() && this.port.getMission().get(0).intValue() == 0) { // 出撃中・遠征中だったら通知しない
+                String message = Messages.getString("cond.recover", this.port.getName());
+                Tools.Controls.showNotify(null, "疲労抜け", message);
+            }
         }
     }
 

--- a/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
+++ b/src/main/resources/META-INF/services/logbook.api.APIListenerSpi
@@ -46,6 +46,7 @@ logbook.api.ApiReqKousyouDestroyship
 logbook.api.ApiReqKousyouGetship
 logbook.api.ApiReqKousyouRemodelSlot
 logbook.api.ApiReqKousyouRemodelSlotlist
+logbook.api.ApiReqMapAnchorageRepair
 logbook.api.ApiReqMapNext
 logbook.api.ApiReqMapStart
 logbook.api.ApiReqMemberItemuse


### PR DESCRIPTION
#### 問題解析
今回のイベントを含む、一部のイベント時にのみ使用可能な7隻艦隊の場合に現在の戦闘が更新されなかったり、戦闘ログが表示されなかったりする。解析を行なった結果7番艦が対空CIを発動すると、その条件式が `idx < 6` となっており艦隊の艦数の上限が6であるという前提で実装されていたため（連合艦隊用の処理に誤って入るため）エラーとなり、結果表記のような問題になっていた。

#### 変更内容
条件式を `idx < ships.size()` のように変更。

それ以外にもマイナーな問題をいくつか修正した。
- 単艦退避をした場合に随伴艦の処理部分でエラーが出ていたのを修正（動作上は退避艦の処理が先のため問題なし）
- 出撃時には疲労なし状態(`cond >= 49`)だったがその後疲労状態になった場合(`cond < 49`)など、一部の条件下で戦闘中に疲労回復時刻告知が出ていたのを修正
- 緊急泊地修理による回復が反映されてなかったのを対応（ただ実際の動作確認をする前に使わなくなってしまったので動作は未確認）

#### 関連するIssue
#48

