### PR TITLE
連合艦隊時の大破チェック修正 Sdk0815#52

### DIFF
--- a/src/main/java/logbook/api/ApiReqMapNext.java
+++ b/src/main/java/logbook/api/ApiReqMapNext.java
@@ -69,8 +69,8 @@ public class ApiReqMapNext implements APIListenerSpi {
                         .get(condition.getDeckId())
                         .getBadlyShips();
 
-                // 連合艦隊時は第2艦隊も見る
-                if (condition.isCombinedFlag()) {
+                // 連合艦隊編成時に第1艦隊出撃中は第2艦隊も見る
+                if (condition.isCombinedFlag() && condition.getDeckId() == 1) {
                     badlyShips.addAll(DeckPortCollection.get()
                             .getDeckPortMap()
                             .get(2).getBadlyShips(AppConfig.get().isIgnoreSecondFlagship()));

--- a/src/main/java/logbook/api/ApiReqMapStart.java
+++ b/src/main/java/logbook/api/ApiReqMapStart.java
@@ -67,8 +67,8 @@ public class ApiReqMapStart implements APIListenerSpi {
                         .get(AppCondition.get().getDeckId())
                         .getBadlyShips();
 
-                // 連合艦隊時は第2艦隊も見る
-                if (AppCondition.get().isCombinedFlag()) {
+                // 連合艦隊編成時に第1艦隊出撃中は第2艦隊も見る
+                if (condition.isCombinedFlag() && condition.getDeckId() == 1) {
                     badlyShips.addAll(DeckPortCollection.get()
                             .getDeckPortMap()
                             .get(2).getBadlyShips(AppConfig.get().isIgnoreSecondFlagship()));


### PR DESCRIPTION
#### 問題解析
大破進撃チェックの時、連合艦隊だったら無条件に第二艦隊も確認していたが、連合艦隊を編成したまま連合艦隊以外（第三、第四艦隊）で出撃していると不要なチェック及び警告が行われていた。

#### 変更内容
連合艦隊出撃時はデータとしては第一艦隊が出撃しているという扱いになっているので、連合艦隊編成のチェックとともに第一艦隊で出撃していることを確認するようにした。

余談だが、大破艦がいるとそもそも出撃できないはず（昔はもしかしたら出撃できた？）なので、出撃時チェックは不要かもしれない。

#### 関連するIssue
#52

