### PR TITLE
雷撃戦のクリティカル処理を修正 Sdk0815#50

### DIFF
--- a/src/main/java/logbook/internal/PhaseState.java
+++ b/src/main/java/logbook/internal/PhaseState.java
@@ -877,7 +877,7 @@ public class PhaseState {
 
                 defender.setNowhp(defender.getNowhp() - damage);
 
-                this.addDetail(attacker, defender, damage, Collections.singletonList(damage), critical,
+                this.addDetail(attacker, defender, damage, Collections.singletonList(damage), Collections.singletonList(critical.get(i)),
                         SortieAtTypeRaigeki.通常雷撃);
             }
         }


### PR DESCRIPTION
#### 問題解析
雷撃戦のデータは攻撃データ（攻撃対象がどの艦でダメージがいくつだったのか、等）が全てまとめられているため、他の砲撃戦等のような１隻ごとの攻撃ごとにデータが分かれているものと内部的な処理を合わせるためデータの差し替えを行なっているが、ダメージの扱いの方はそれが行われていたがクリティカルフラグに関しては行われておらず、表記の問題が起きていた。コードを見ただけで実際に確認してはいないが、表記のような現象以外にも旗艦がクリティカルを出した場合は全艦クリティカル扱いになっていたと思われる。

#### 変更内容
ダメージの方と同様、クリティカルフラグに関しても扱いを変更した。

#### 関連するIssue
#50

