### PR TITLE
テーブル列の並び順を保持 Sdk0815#43

### DIFF
--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -203,6 +204,9 @@ public final class AppConfig implements Serializable {
 
     /** テーブル列のソート順 */
     private Map<String, Map<String, String>> columnSortOrderMap = new LinkedHashMap<>();
+
+    /** テーブル列の並び順 */
+    private Map<String, List<String>> columnOrderMap = new LinkedHashMap<>();
 
     /** SplitPaneの分割サイズ */
     private Map<String, Double> dividerPositionMap = new HashMap<>();

--- a/src/main/java/logbook/internal/gui/ColumnVisibleController.java
+++ b/src/main/java/logbook/internal/gui/ColumnVisibleController.java
@@ -57,7 +57,10 @@ public class ColumnVisibleController extends WindowController {
         AppConfig.get()
                 .getColumnWidthMap()
                 .remove(this.key);
-        Tools.Controls.alert(AlertType.INFORMATION, "列幅をリセット", "列幅がリセットされました。\n再度ウインドウを開いたときに反映されます。",
+        AppConfig.get()
+                .getColumnOrderMap()
+                .remove(this.key);
+        Tools.Controls.alert(AlertType.INFORMATION, "列幅・並び順をリセット", "列幅・並び順がリセットされました。\n再度ウインドウを開いたときに反映されます。",
                 this.getWindow());
     }
 

--- a/src/main/java/logbook/internal/gui/TableTool.java
+++ b/src/main/java/logbook/internal/gui/TableTool.java
@@ -98,6 +98,7 @@ class TableTool {
         Tools.Tables.setVisible(table, key);
         Tools.Tables.setWidth(table, key);
         Tools.Tables.setSortOrder(table, key);
+        Tools.Tables.setColumnOrder(table, key);
     }
 
     static <T> Callback<TableColumn<T, Integer>, TableCell<T, Integer>> getRowCountCellFactory() {

--- a/src/main/java/logbook/internal/gui/TreeTableTool.java
+++ b/src/main/java/logbook/internal/gui/TreeTableTool.java
@@ -12,5 +12,6 @@ public class TreeTableTool {
         //Tools.Trees.setVisible(table, key);   // not yet implemented
         Tools.Trees.setWidth(table, key);
         Tools.Trees.setSortOrder(table, key);
+        Tools.Trees.setColumnOrder(table, key);
     }
 }

--- a/src/main/resources/logbook/gui/column_visible.fxml
+++ b/src/main/resources/logbook/gui/column_visible.fxml
@@ -28,7 +28,7 @@
                </padding>
             </Button>
             <Pane HBox.hgrow="ALWAYS" />
-            <Button mnemonicParsing="false" onAction="#resetWidth" text="列幅をリセット">
+            <Button mnemonicParsing="false" onAction="#resetWidth" text="列幅・並び順をリセット">
                <HBox.margin>
                   <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
                </HBox.margin>


### PR DESCRIPTION
#### 変更内容
テーブル列の並び順を保持するようにした。列幅のリセットのボタンを拡張して並び順のリセットも追加しておく。

もともと実装されていなかったのでバグとすべきかどうかは微妙なところだが、並び順自体は変更できるようになっていたのでバグのカテゴリのままにしておくことにする。

#### 関連するIssue
#43

