### PR TITLE
新艦娘のパラメータ更新（Honolulu改、宗谷（南極）を除く）

### DIFF
--- a/src/main/resources/logbook/supplemental/ships.json
+++ b/src/main/resources/logbook/supplemental/ships.json
@@ -3384,6 +3384,12 @@
     "min_kaihi" : 34,
     "min_sakuteki" : 11
   }, {
+    "id" : 598,
+    "name" : "Honolulu",
+    "min_taisen" : 0,
+    "min_kaihi" : 32,
+    "min_sakuteki" : 17
+  }, {
     "id" : 599,
     "name" : "赤城改二戊",
     "min_taisen" : 0,
@@ -3618,6 +3624,18 @@
     "min_kaihi" : 34,
     "min_sakuteki" : 9
   }, {
+    "id" : 644,
+    "name" : "桃",
+    "min_taisen" : 27,
+    "min_kaihi" : 31,
+    "min_sakuteki" : 8
+  }, {
+    "id" : 645,
+    "name" : "宗谷",
+    "min_taisen" : 1,
+    "min_kaihi" : 26,
+    "min_sakuteki" : 14
+  }, {
     "id" : 646,
     "name" : "加賀改二護",
     "min_taisen" : 72,
@@ -3629,6 +3647,12 @@
     "min_taisen" : 28,
     "min_kaihi" : 47,
     "min_sakuteki" : 10
+  }, {
+    "id" : 649,
+    "name" : "高波改二",
+    "min_taisen" : 30,
+    "min_kaihi" : 48,
+    "min_sakuteki" : 14
   }, {
     "id" : 651,
     "name" : "丹陽",
@@ -3652,6 +3676,12 @@
     "name" : "Washington",
     "min_taisen" : 0,
     "min_kaihi" : 26,
+    "min_sakuteki" : 14
+  }, {
+    "id" : 655,
+    "name" : "Northampton",
+    "min_taisen" : 0,
+    "min_kaihi" : 36,
     "min_sakuteki" : 14
   }, {
     "id" : 656,
@@ -3678,6 +3708,12 @@
     "min_kaihi" : 35,
     "min_sakuteki" : 18
   }, {
+    "id" : 660,
+    "name" : "Northampton改",
+    "min_taisen" : 0,
+    "min_kaihi" : 34,
+    "min_sakuteki" : 15
+  }, {
     "id" : 662,
     "name" : "能代改二",
     "min_taisen" : 32,
@@ -3701,6 +3737,18 @@
     "min_taisen" : 30,
     "min_kaihi" : 42,
     "min_sakuteki" : 15
+  }, {
+    "id" : 671,
+    "name" : "巻波",
+    "min_taisen" : 24,
+    "min_kaihi" : 43,
+    "min_sakuteki" : 9
+  }, {
+    "id" : 675,
+    "name" : "涼波",
+    "min_taisen" : 24,
+    "min_kaihi" : 42,
+    "min_sakuteki" : 9
   }, {
     "id" : 678,
     "name" : "日振改",
@@ -3810,6 +3858,12 @@
     "min_kaihi" : 28,
     "min_sakuteki" : 51
   }, {
+    "id" : 699,
+    "name" : "宗谷",
+    "min_taisen" : 8,
+    "min_kaihi" : 27,
+    "min_sakuteki" : 2
+  }, {
     "id" : 700,
     "name" : "薄雲改",
     "min_taisen" : 22,
@@ -3852,11 +3906,41 @@
     "min_kaihi" : 37,
     "min_sakuteki" : 14
   }, {
+    "id" : 708,
+    "name" : "桃改",
+    "min_taisen" : 33,
+    "min_kaihi" : 36,
+    "min_sakuteki" : 13
+  }, {
+    "id" : 709,
+    "name" : "巻波改",
+    "min_taisen" : 27,
+    "min_kaihi" : 35,
+    "min_sakuteki" : 11
+  }, {
+    "id" : 710,
+    "name" : "涼波改",
+    "min_taisen" : 26,
+    "min_kaihi" : 37,
+    "min_sakuteki" : 10
+  }, {
+    "id" : 882,
+    "name" : "伊203",
+    "min_taisen" : 0,
+    "min_kaihi" : 40,
+    "min_sakuteki" : 8
+  }, {
     "id" : 883,
     "name" : "龍鳳改二戊",
     "min_taisen" : 36,
     "min_kaihi" : 40,
     "min_sakuteki" : 30
+  }, {
+    "id" : 887,
+    "name" : "伊203改",
+    "min_taisen" : 0,
+    "min_kaihi" : 44,
+    "min_sakuteki" : 14
   }, {
     "id" : 888,
     "name" : "龍鳳改二",


### PR DESCRIPTION
#### 変更内容
前回更新以降に実装された艦娘のパラメータを更新。ただ現時点(7/3)で判明していないHonolulu改と宗谷（南極観測船）を除く。宗谷に関しては改装しても名前が同じなので間違いやすいが、ID 650の定義が南極観測船なので判明した際は650を更新すること。

#### 関連するIssue
N/A

